### PR TITLE
Update dependency to latest release of embedded-sdmmc

### DIFF
--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -26,7 +26,7 @@ cortex-m-rtic = "1.1.2"
 nb = "1.0"
 i2c-pio = "0.6.0"
 heapless = "0.7.9"
-embedded-sdmmc = { git = "https://github.com/rust-embedded-community/embedded-sdmmc-rs.git", rev = "db58253bb326d20e177c733ebc0b051ef0dcee0f" }
+embedded-sdmmc = "0.4.0"
 smart-leds = "0.3.0"
 ws2812-pio = "0.6.0"
 ssd1306 = "0.7.0"


### PR DESCRIPTION
This avoids a git dependency.

As I don't have the necessary hardware at hand to test this, it is only compile-tested.