### PR TITLE
doc: Update readmes to use the new repo's name

### DIFF
--- a/boards/adafruit-feather-rp2040/README.md
+++ b/boards/adafruit-feather-rp2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/adafruit-feather-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/adafruit-feather-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/adafruit-feather-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/adafruit-feather-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -74,7 +74,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/adafruit-itsy-bitsy-rp2040/README.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/adafruit-itsy-bitsy-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/adafruit-itsy-bitsy-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/adafruit-itsy-bitsy-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/adafruit-itsy-bitsy-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -74,7 +74,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/adafruit-kb2040/README.md
+++ b/boards/adafruit-kb2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/adafruit-kb2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/adafruit-kb2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/adafruit-kb2040$ cargo run --release --example <name>
+rp-hal-boards/boards/adafruit-kb2040$ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -70,7 +70,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/adafruit-macropad/README.md
+++ b/boards/adafruit-macropad/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/adafruit-macropad $ cargo build --release --example <name>
+rp-hal-boards/boards/adafruit-macropad $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/adafruit-macropad $ cargo run --release --example <name>
+rp-hal-boards/boards/adafruit-macropad $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -66,7 +66,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/adafruit-qt-py-rp2040/README.md
+++ b/boards/adafruit-qt-py-rp2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/adafruit-qt-py-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/adafruit-qt-py-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/adafruit-qt-py-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/adafruit-qt-py-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -70,7 +70,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/adafruit-trinkey-qt2040/README.md
+++ b/boards/adafruit-trinkey-qt2040/README.md
@@ -26,15 +26,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/adafruit-trinkey-qt2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/adafruit-trinkey-qt2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -43,7 +43,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/adafruit-trinkey-qt2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/adafruit-trinkey-qt2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -69,7 +69,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/arduino_nano_connect/README.md
+++ b/boards/arduino_nano_connect/README.md
@@ -29,15 +29,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/arduino_nano_connect $ cargo build --release --example <name>
+rp-hal-boards/boards/arduino_nano_connect $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -46,7 +46,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/arduino_nano_connect $ cargo run --release --example <name>
+rp-hal-boards/boards/arduino_nano_connect $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -74,7 +74,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/pimoroni-badger2040/README.md
+++ b/boards/pimoroni-badger2040/README.md
@@ -28,15 +28,15 @@ devices and configure common clocks. See the [examples](./examples) folder for m
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/pimoroni-badger2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/pimoroni-badger2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -45,7 +45,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/pimoroni-badger2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/pimoroni-badger2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -72,7 +72,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/pimoroni-pico-explorer/README.md
+++ b/boards/pimoroni-pico-explorer/README.md
@@ -28,15 +28,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/pimoroni-pico-explorer $ cargo build --release --example <name>
+rp-hal-boards/boards/pimoroni-pico-explorer $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -45,7 +45,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/pimoroni-pico-explorer $ cargo run --release --example <name>
+rp-hal-boards/boards/pimoroni-pico-explorer $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -71,7 +71,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/pimoroni-pico-lipo-16mb/README.md
+++ b/boards/pimoroni-pico-lipo-16mb/README.md
@@ -29,15 +29,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/pimoroni-pico-lipo-16mb $ cargo build --release --example <name>
+rp-hal-boards/boards/pimoroni-pico-lipo-16mb $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -46,7 +46,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/pimoroni-pico-lipo-16mb $ cargo run --release --example <name>
+rp-hal-boards/boards/pimoroni-pico-lipo-16mb $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -72,7 +72,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/pimoroni-plasma-2040/README.md
+++ b/boards/pimoroni-plasma-2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/pimoroni-plasma-2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/pimoroni-plasma-2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/pimoroni-plasma-2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/pimoroni-plasma-2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -76,7 +76,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/pimoroni-servo2040/README.md
+++ b/boards/pimoroni-servo2040/README.md
@@ -28,15 +28,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/pimoroni-servo2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/pimoroni-servo2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -45,7 +45,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/pimoroni-servo2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/pimoroni-servo2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -87,7 +87,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/pimoroni-tiny2040/README.md
+++ b/boards/pimoroni-tiny2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/pimoroni-tiny2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/pimoroni-tiny2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/pimoroni-tiny2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/pimoroni-tiny2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -71,7 +71,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/rp-pico/README.md
+++ b/boards/rp-pico/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/rp-pico $ cargo build --release --example <name>
+rp-hal-boards/boards/rp-pico $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/rp-pico $ cargo run --release --example <name>
+rp-hal-boards/boards/rp-pico $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -143,7 +143,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/seeeduino-xiao-rp2040/README.md
+++ b/boards/seeeduino-xiao-rp2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/seeeduino-xiao-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/seeeduino-xiao-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/seeeduino-xiao-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/seeeduino-xiao-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -72,7 +72,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/solderparty-rp2040-stamp/README.md
+++ b/boards/solderparty-rp2040-stamp/README.md
@@ -30,12 +30,12 @@ devices. See the [examples](./examples) folder for more details.
 To compile an example, clone the _rp-hal_ repository and run:
 
 ```console
-rp-hal/boards/solderparty-rp2040-stamp $ cargo build --release --example <name>
+rp-hal-boards/boards/solderparty-rp2040-stamp $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/solderparty-rp2040-stamp $ cargo run --release --example <name>
+rp-hal-boards/boards/solderparty-rp2040-stamp $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -70,7 +70,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/sparkfun-pro-micro-rp2040/README.md
+++ b/boards/sparkfun-pro-micro-rp2040/README.md
@@ -28,15 +28,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/sparkfun-pro-micro-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/sparkfun-pro-micro-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -45,7 +45,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/sparkfun-pro-micro-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/sparkfun-pro-micro-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -71,7 +71,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/sparkfun-thing-plus-rp2040/README.md
+++ b/boards/sparkfun-thing-plus-rp2040/README.md
@@ -28,15 +28,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/sparkfun-thing-plus-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/sparkfun-thing-plus-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -45,7 +45,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/sparkfun-thing-plus-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/sparkfun-thing-plus-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -71,7 +71,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/vcc-gnd-yd-rp2040/README.md
+++ b/boards/vcc-gnd-yd-rp2040/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/vcc-gnd-yd-rp2040 $ cargo build --release --example <name>
+rp-hal-boards/boards/vcc-gnd-yd-rp2040 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/vcc-gnd-yd-rp2040 $ cargo run --release --example <name>
+rp-hal-boards/boards/vcc-gnd-yd-rp2040 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -75,7 +75,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/waveshare-rp2040-lcd-0-96/README.md
+++ b/boards/waveshare-rp2040-lcd-0-96/README.md
@@ -28,15 +28,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/waveshare-rp2040-lcd-0-96 $ cargo build --release --example <name>
+rp-hal-boards/boards/waveshare-rp2040-lcd-0-96 $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -45,7 +45,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/waveshare-rp2040-lcd-0-96 $ cargo run --release --example <name>
+rp-hal-boards/boards/waveshare-rp2040-lcd-0-96 $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -73,7 +73,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 

--- a/boards/waveshare-rp2040-zero/README.md
+++ b/boards/waveshare-rp2040-zero/README.md
@@ -27,15 +27,15 @@ devices. See the [examples](./examples) folder for more details.
 
 ### General Instructions
 
-To compile an example, clone the _rp-hal_ repository and run:
+To compile an example, clone the _rp-hal-boards_ repository and run:
 
 ```console
-rp-hal/boards/waveshare-rp2040-zero $ cargo build --release --example <name>
+rp-hal-boards/boards/waveshare-rp2040-zero $ cargo build --release --example <name>
 ```
 
 You will get an ELF file called
 `./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
-folder is located at the top of the _rp-hal_ repository checkout. Normally
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
 you would also need to specify `--target=thumbv6m-none-eabi` but when
 building examples from this git repository, that is set as the default.
 
@@ -44,7 +44,7 @@ USB drive exported by the RP2040 bootloader, simply boot your board into
 bootloader mode and run:
 
 ```console
-rp-hal/boards/waveshare-rp2040-zero $ cargo run --release --example <name>
+rp-hal-boards/boards/waveshare-rp2040-zero $ cargo run --release --example <name>
 ```
 
 If you get an error about not being able to find `elf2uf2-rs`, try:
@@ -70,7 +70,7 @@ The steps are:
 3. Make some changes to the code or documentation.
 4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
-6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
 7. An admin will review the Pull Request and discuss any changes that may be required.
 8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
 


### PR DESCRIPTION
This fixes inconsistencies in the readme visible on crates.io as reported by Slushee [here](https://matrix.to/#/!zbjndUiYJDvhDRkPGw:matrix.org/$Ug6UoV-Lh_FxRdiPspVACvFn2urvRUXkWvQVeqwRPIU?via=matrix.org&via=boiler.social&via=community.rs).