### PR TITLE
Remove redundant variable in pico uart examples

### DIFF
--- a/boards/rp-pico/examples/pico_uart_irq_buffer.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_buffer.rs
@@ -73,10 +73,6 @@ struct UartQueue {
     interrupt: pac::Interrupt,
 }
 
-/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
-/// if your board has a different frequency
-const XTAL_FREQ_HZ: u32 = 12_000_000u32;
-
 /// This how we transfer the UART into the Interrupt Handler
 static GLOBAL_UART: Mutex<RefCell<Option<Uart>>> = Mutex::new(RefCell::new(None));
 
@@ -105,7 +101,7 @@ fn main() -> ! {
 
     // Configure the clocks
     let clocks = hal::clocks::init_clocks_and_plls(
-        XTAL_FREQ_HZ,
+        rp_pico::XOSC_CRYSTAL_FREQ,
         pac.XOSC,
         pac.CLOCKS,
         pac.PLL_SYS,

--- a/boards/rp-pico/examples/pico_uart_irq_echo.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_echo.rs
@@ -64,10 +64,6 @@ type UartPins = (
 /// Alias the type for our UART to make things clearer.
 type Uart = hal::uart::UartPeripheral<hal::uart::Enabled, pac::UART0, UartPins>;
 
-/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
-/// if your board has a different frequency
-const XTAL_FREQ_HZ: u32 = 12_000_000u32;
-
 /// This how we transfer the UART into the Interrupt Handler
 static GLOBAL_UART: Mutex<RefCell<Option<Uart>>> = Mutex::new(RefCell::new(None));
 
@@ -89,7 +85,7 @@ fn main() -> ! {
 
     // Configure the clocks
     let clocks = hal::clocks::init_clocks_and_plls(
-        XTAL_FREQ_HZ,
+        rp_pico::XOSC_CRYSTAL_FREQ,
         pac.XOSC,
         pac.CLOCKS,
         pac.PLL_SYS,


### PR DESCRIPTION
This removes the hard-coded XTAL_FREQ_HZ variable from the rp-pico UART examples as it's already defined in this library as XOSC_CRYSTAL_FREQ.

I noticed this as I was looking thru the examples and it seems like most of them use the rp_pico::XOSC_CRYSTAL_FREQ value instead. I'm new to embedded so please let me know if I got something wrong here. Thanks!