### PR TITLE
Update probe-run list-probes command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ programming pins on your RP2040 board. Check the probe has been found by
 running:
 
 ```console
-$ probe-run --chip RP2040 --list-probes
+$ probe-run --list-probes
 The following devices were found:
 [0]: J-Link (J-Link) (VID: 1366, PID: 0101, Serial: 000099999999, JLink)
 ```


### PR DESCRIPTION
Hi, I noticed when I followed the [current instructions](https://github.com/rp-rs/rp-hal-boards/blob/2f8d0f4404c32cf8877c57812dd3649a80431380/README.md?plain=1#L413) in the README to use probe-run, I got an error:

```sh
probe-run --chip RP2040 --list-probes
error: the argument '--chip <CHIP>' cannot be used with '--list-probes'

Usage: probe-run --chip <CHIP> <ELF>

For more information, try '--help'.
```

I'm on macOS Monterey 12.6.5 (21G531) and currently here's my version from probe-run:

```sh
probe-run --version
0.3.8
supported defmt version: 4
```

Once I removed the `--chip` argument I got this:

```sh
probe-run --list-probes
the following probes were found:
[0]: Picoprobe CMSIS-DAP (VID: 2e8a, PID: 000c, Serial: E6616408438E3C21, CmsisDap)
```

I am guessing this is the intended behaviour, and that the `--chip` and `--list-probes` arguments no longer work together.