### PR TITLE
feat: transitively expose the rp-2040 eh1_0_alpha feature

### DIFF
--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -17,8 +17,8 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
 nb = "1.1.0"
 smart-leds = "0.3.0"
@@ -35,7 +35,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
@@ -49,3 +49,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "adafruit-itsy-bitsy-rp2040"
 version = "0.7.0"
-authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
+authors = [
+  "Andrew Christiansen <andrewtaylorchristiansen@gmail.com>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit_itsy_bitsy_rp2040"
 description = "Board Support Package for the Adafruit ItsyBitsy RP2040"
@@ -17,8 +20,8 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 smart-leds = "0.3"
 nb = "1.1.0"
 ws2812-pio = "0.7.0"
@@ -35,7 +38,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
@@ -49,3 +52,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "adafruit-kb2040"
 version = "0.7.0"
-authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
+authors = [
+  "Andrew Christiansen <andrewtaylorchristiansen@gmail.com>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-kb2040"
 description = "Board Support Package for the Adafruit adafruit-kb2040"
@@ -13,6 +16,8 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 [dependencies]
 cortex-m-rt = { version = "0.7.3", optional = true }
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
@@ -35,7 +40,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
@@ -49,3 +54,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -17,8 +17,8 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-embedded-hal ="0.2.7"
-panic-halt= "0.2.0"
+embedded-hal = "0.2.7"
+panic-halt = "0.2.0"
 
 [features]
 # This is the set of features we enable by default
@@ -31,7 +31,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
@@ -45,3 +45,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -16,8 +16,8 @@ rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 smart-leds = "0.3"
 nb = "1.1.0"
 ws2812-pio = "0.7.0"
@@ -34,7 +34,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -48,3 +48,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/adafruit-trinkey-qt2040/Cargo.toml
+++ b/boards/adafruit-trinkey-qt2040/Cargo.toml
@@ -16,8 +16,8 @@ rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 smart-leds = "0.3"
 nb = "1.1.0"
 ws2812-pio = "0.7.0"
@@ -34,7 +34,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -48,3 +48,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -13,13 +13,15 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 [dependencies]
 cortex-m-rt = { version = "0.7.3", optional = true }
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 nb = "1.1"
 fugit = "0.3.7"
 
@@ -34,7 +36,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -48,3 +50,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/boardsource-blok/Cargo.toml
+++ b/boards/boardsource-blok/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 
 [dependencies]
 cortex-m = "0.7.7"
-rp2040-boot2 = { version = "0.3.0", optional = true}
-rp2040-hal = { version = "0.9.0"}
-cortex-m-rt = { version = "0.7.3", optional = true}
+rp2040-boot2 = { version = "0.3.0", optional = true }
+rp2040-hal = { version = "0.9.0" }
+cortex-m-rt = { version = "0.7.3", optional = true }
 fugit = "0.3.5"
 
 [dev-dependencies]
@@ -38,7 +38,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -52,3 +52,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -15,6 +15,8 @@ cortex-m-rt = { version = "0.7", optional = true }
 display-interface-spi = "0.4.1"
 embedded-graphics = "0.7.1"
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 fugit = "0.3.7"
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
@@ -52,3 +54,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/pimoroni-pico-lipo-16mb/Cargo.toml
+++ b/boards/pimoroni-pico-lipo-16mb/Cargo.toml
@@ -17,8 +17,8 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 nb = "1.1"
 
 [features]
@@ -32,7 +32,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -46,3 +46,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -17,10 +17,10 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
-panic-halt= "0.2.0"
-rp2040-hal = { version = "0.9.0", features = [ "defmt" ] }
+panic-halt = "0.2.0"
+rp2040-hal = { version = "0.9.0", features = ["defmt"] }
 smart-leds = "0.3.0"
 ws2812-pio = "0.7.0"
 
@@ -38,7 +38,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -52,3 +52,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/pimoroni-servo2040/Cargo.toml
+++ b/boards/pimoroni-servo2040/Cargo.toml
@@ -18,11 +18,11 @@ rp2040-hal = { version = "0.9.0" }
 [dev-dependencies]
 defmt = "0.3.5"
 defmt-rtt = "0.4.0"
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
 nb = "1.1.0"
-panic-halt= "0.2.0"
-rp2040-hal = { version = "0.9.0", features = [ "defmt" ] }
+panic-halt = "0.2.0"
+rp2040-hal = { version = "0.9.0", features = ["defmt"] }
 smart-leds = "0.3.0"
 ws2812-pio = "0.7.0"
 
@@ -37,7 +37,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -51,3 +51,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -17,10 +17,10 @@ rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
-panic-halt= "0.2.0"
-rp2040-hal = { version = "0.9.0", features = [ "defmt" ]  }
+panic-halt = "0.2.0"
+rp2040-hal = { version = "0.9.0", features = ["defmt"] }
 
 defmt = "0.3.5"
 defmt-rtt = "0.4.0"
@@ -36,7 +36,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -50,3 +50,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/pimoroni_badger2040/Cargo.toml
+++ b/boards/pimoroni_badger2040/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-hal = "0.2.7"
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 fugit = "0.3.7"
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
@@ -46,3 +48,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -15,23 +15,23 @@ cortex-m-rt = { version = "0.7", optional = true }
 fugit = "0.3.7"
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
-usb-device= "0.2.9"
+usb-device = "0.2.9"
 
 [dev-dependencies]
 cortex-m = "0.7.7"
 cortex-m-rtic = "1.1.4"
 critical-section = "1.1.2"
 embedded-graphics = "0.7.1"
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 embedded-sdmmc = "0.5.0"
 hd44780-driver = "0.4.0"
 heapless = "0.7.16"
 i2c-pio = "0.7.0"
 nb = "1.1"
-panic-halt= "0.2.0"
+panic-halt = "0.2.0"
 pio = "0.2.1"
 pio-proc = "0.2.2"
-rp2040-hal = { version = "0.9.0", features = [ "defmt" ] }
+rp2040-hal = { version = "0.9.0", features = ["defmt"] }
 smart-leds = "0.3.0"
 ssd1306 = "0.7.1"
 usbd-hid = "0.5.2"
@@ -52,7 +52,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -66,6 +66,9 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]
 
 [[example]]
 name = "pico_rtic_monotonic"

--- a/boards/seeeduino-xiao-rp2040/Cargo.toml
+++ b/boards/seeeduino-xiao-rp2040/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "seeeduino-xiao-rp2040"
 version = "0.5.0"
-authors = ["Philip L. McMahon <plm@users.noreply.github.com>", "The rp-rs Developers"]
+authors = [
+  "Philip L. McMahon <plm@users.noreply.github.com>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/seeeduino-xiao-rp02040"
 description = "Board Support Package for the Seeediuno XIAO RP2040"
@@ -17,10 +20,10 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
 nb = "1.1"
-panic-halt= "0.2.0"
+panic-halt = "0.2.0"
 
 [features]
 # This is the set of features we enable by default
@@ -33,7 +36,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -47,3 +50,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/solderparty-rp2040-stamp/Cargo.toml
+++ b/boards/solderparty-rp2040-stamp/Cargo.toml
@@ -16,10 +16,10 @@ rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
 nb = "1.1.0"
-panic-halt= "0.2.0"
+panic-halt = "0.2.0"
 pio = "0.2.1"
 smart-leds = "0.3.0"
 ws2812-pio = "0.7.0"
@@ -35,7 +35,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -49,3 +49,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/sparkfun-micromod-rp2040/Cargo.toml
+++ b/boards/sparkfun-micromod-rp2040/Cargo.toml
@@ -16,6 +16,8 @@ rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 cortex-m-rt = { version = "0.7.3", optional = true }
 embedded-hal = "0.2.7"
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 nb = "1.1.0"
 
 [dev-dependencies]
@@ -50,3 +52,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "sparkfun-pro-micro-rp2040"
 version = "0.7.0"
-authors = ["Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
+authors = [
+  "Wilfried Chauveau <wilfried.chauveau@ithinuel.me>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/sparkfun-pro-micro-rp2040"
 description = "Board Support Package for the Sparkfun Pro Micro RP2040"
@@ -13,6 +16,8 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 [dependencies]
 cortex-m-rt = { version = "0.7.3", optional = true }
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
@@ -35,7 +40,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -49,3 +54,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/sparkfun-thing-plus-rp2040/Cargo.toml
+++ b/boards/sparkfun-thing-plus-rp2040/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "sparkfun-thing-plus-rp2040"
 version = "0.6.0"
-authors = ["Tyler Pottenger <tyler.pottenger@gmail.com>", "Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
+authors = [
+  "Tyler Pottenger <tyler.pottenger@gmail.com>",
+  "Wilfried Chauveau <wilfried.chauveau@ithinuel.me>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/sparkfun-thing-plus-rp2040"
 description = "Board Support Package for the Sparkfun Thing Plus RP2040"
@@ -13,6 +17,8 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 [dependencies]
 cortex-m-rt = { version = "0.7.3", optional = true }
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
+eh1_0_alpha = { package = "embedded-hal", version = "=1.0.0-alpha.11", optional = true }
+eh_nb_1_0_alpha = { package = "embedded-hal-nb", version = "=1.0.0-alpha.3", optional = true }
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
 
@@ -35,7 +41,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -49,3 +55,10 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = [
+  "dep:eh1_0_alpha",
+  "dep:eh_nb_1_0_alpha",
+  "rp2040-hal/eh1_0_alpha",
+]

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -15,13 +15,13 @@ cortex-m-rt = { version = "0.7", optional = true }
 fugit = "0.3.7"
 rp2040-boot2 = { version = "0.3.0", optional = true }
 rp2040-hal = { version = "0.9.0" }
-usb-device= "0.2.9"
+usb-device = "0.2.9"
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-embedded-hal ="0.2.7"
+embedded-hal = "0.2.7"
 nb = "1.1"
-panic-halt= "0.2.0"
+panic-halt = "0.2.0"
 pio = "0.2.1"
 smart-leds = "0.3.0"
 ws2812-pio = "0.7.0"
@@ -37,7 +37,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
@@ -51,3 +51,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/waveshare-rp2040-lcd-0-96/Cargo.toml
+++ b/boards/waveshare-rp2040-lcd-0-96/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "waveshare-rp2040-lcd-0-96"
 version = "0.7.0"
-authors = ["René van Dorst <opensource@vdorst.com>", "Andrea Nall <anall@andreanal.com>", "TilCreator <contact.github@tc-j.de>", "The rp-rs Developers"]
+authors = [
+  "René van Dorst <opensource@vdorst.com>",
+  "Andrea Nall <anall@andreanal.com>",
+  "TilCreator <contact.github@tc-j.de>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/waveshare-rp2040-lcd-0_96"
 description = "Board Support Package for the Waveshare RP2040 LCD 0.96 inch"
@@ -17,8 +22,8 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
 nb = "1.1.0"
 embedded-graphics = "0.7.1"
@@ -35,7 +40,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
@@ -49,3 +54,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]

--- a/boards/waveshare-rp2040-zero/Cargo.toml
+++ b/boards/waveshare-rp2040-zero/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "waveshare-rp2040-zero"
 version = "0.7.0"
-authors = ["Andrea Nall <anall@andreanal.com>", "TilCreator <contact.github@tc-j.de>", "The rp-rs Developers"]
+authors = [
+  "Andrea Nall <anall@andreanal.com>",
+  "TilCreator <contact.github@tc-j.de>",
+  "The rp-rs Developers",
+]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/waveshare-rp2040-zero"
 description = "Board Support Package for the Adafruit Feather RP2040"
@@ -17,8 +21,8 @@ rp2040-hal = { version = "0.9.0" }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
-panic-halt= "0.2.0"
-embedded-hal ="0.2.7"
+panic-halt = "0.2.0"
+embedded-hal = "0.2.7"
 fugit = "0.3.7"
 nb = "1.1.0"
 smart-leds = "0.3.0"
@@ -35,7 +39,7 @@ critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 
 # Minimal startup / runtime for Cortex-M microcontrollers
-rt = ["cortex-m-rt","rp2040-hal/rt"]
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
 
 # This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
 # Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
@@ -49,3 +53,6 @@ disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
 
 # This enables ROM functions for f64 math that were not present in the earliest RP2040s
 rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]
+
+# Support alpha release of embedded-hal
+eh1_0_alpha = ["rp2040-hal/eh1_0_alpha"]


### PR DESCRIPTION
This transitively exposes the `eh1_0_alpha` feature so that it's easier to use/patch BSPs with the newer releases of embedded-hal via rp-hal.

There are some BSPs that use embedded-hal directly, as I don't have the affected boards I didn't want to mess about with the code and break anything. I replicated what's done in the rp2040-hal - these dependencies should probably be removed and accessed via the re-exported `hal`.