### PR TITLE
Fix out-of-date comment about SPI pins not being used

### DIFF
--- a/boards/rp-pico/examples/pico_spi_sd_card.rs
+++ b/boards/rp-pico/examples/pico_spi_sd_card.rs
@@ -206,13 +206,13 @@ fn main() -> ! {
     // Set the LED to be an output
     let mut led_pin = pins.led.into_push_pull_output();
 
-    // These are implicitly used by the spi driver if they are in the correct mode
+    // Set up our SPI pins into the correct mode
     let spi_sclk: gpio::Pin<_, gpio::FunctionSpi, gpio::PullNone> = pins.gpio2.reconfigure();
     let spi_mosi: gpio::Pin<_, gpio::FunctionSpi, gpio::PullNone> = pins.gpio3.reconfigure();
     let spi_miso: gpio::Pin<_, gpio::FunctionSpi, gpio::PullUp> = pins.gpio4.reconfigure();
     let spi_cs = pins.gpio5.into_push_pull_output();
 
-    // Create an SPI driver instance for the SPI0 device
+    // Create the SPI driver instance for the SPI0 device
     let spi = spi::Spi::<_, _, _, 8>::new(pac.SPI0, (spi_mosi, spi_miso, spi_sclk));
 
     // Exchange the uninitialised SPI driver for an initialised one


### PR DESCRIPTION
Also replace 'an' with 'the', because SPI could be pronounced ess-pee-eye or spy, so either of those choices is going to annoy someone.