### PR TITLE
Update boardsource_blok pinout

### DIFF
--- a/boards/boardsource-blok/CHANGELOG.md
+++ b/boards/boardsource-blok/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.1 - 2023-10-25
+
+### Changed
+
+- Updated pinout
+
 ## 0.2.0 - 2023-09-02
 
 ### Changed

--- a/boards/boardsource-blok/Cargo.toml
+++ b/boards/boardsource-blok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boardsource-blok"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Agent59 <agent59@ripakewitz.net>", "The rp-rs Developers"]
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/boardsource-blok"

--- a/boards/boardsource-blok/src/lib.rs
+++ b/boards/boardsource-blok/src/lib.rs
@@ -47,7 +47,6 @@ hal::bsp_pins!(
         }
     },
 
-
     /// GPIO 1 supports following functions:
     ///
     /// | Function     | Alias with applied function |

--- a/boards/boardsource-blok/src/lib.rs
+++ b/boards/boardsource-blok/src/lib.rs
@@ -18,75 +18,513 @@ pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 pub use hal::pac;
 
 hal::bsp_pins!(
+
+    /// GPIO 0 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp0Spi0Rx]          |
+    /// | `UART0 TX`   | [crate::Gp0Uart0Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp0I2C0Sda]         |
+    /// | `PWM0 A`     | [crate::Gp0Pwm0A]           |
+    /// | `PIO0`       | [crate::Gp0Pio0]            |
+    /// | `PIO1`       | [crate::Gp0Pio1]            |
     Gpio0 {
-        name: tx,
-        aliases: { FunctionUart, PullNone: Gp0Uart0Tx }
-    },
-    Gpio1 {
-        name: rx,
-        aliases: { FunctionUart, PullNone: Gp0Uart0Rx }
-    },
-    Gpio16 {
-        name: sda,
-        aliases: { FunctionI2C, PullUp: Gp16I2C0Sda}
-    },
-    Gpio17 {
-        name: scl,
-        aliases: { FunctionI2C, PullUp: Gp17I2C0Scl }
+        name: gpio0,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio0].
+            FunctionUart, PullNone: Gp0Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio0].
+            FunctionSpi, PullNone: Gp0Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio0].
+            FunctionI2C, PullUp: Gp0I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio0].
+            FunctionPwm, PullNone: Gp0Pwm0A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio0, PullNone: Gp0Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio1, PullNone: Gp0Pio1
+        }
     },
 
+
+    /// GPIO 1 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp1Spi0Csn]         |
+    /// | `UART0 RX`   | [crate::Gp1Uart0Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp1I2C0Scl]         |
+    /// | `PWM0 B`     | [crate::Gp1Pwm0B]           |
+    /// | `PIO0`       | [crate::Gp1Pio0]            |
+    /// | `PIO1`       | [crate::Gp1Pio1]            |
+    Gpio1 {
+        name: gpio1,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio1].
+            FunctionUart, PullNone: Gp1Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio1].
+            FunctionSpi, PullNone: Gp1Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio1].
+            FunctionI2C, PullUp: Gp1I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio1].
+            FunctionPwm, PullNone: Gp1Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio0, PullNone: Gp1Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio1, PullNone: Gp1Pio1
+        }
+    },
+
+    /// GPIO 16 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp16Spi0Rx]         |
+    /// | `UART0 TX`   | [crate::Gp16Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp16I2C0Sda]        |
+    /// | `PWM0 A`     | [crate::Gp16Pwm0A]          |
+    /// | `PIO0`       | [crate::Gp16Pio0]           |
+    /// | `PIO1`       | [crate::Gp16Pio1]           |
+    Gpio16 {
+        name: gpio16,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio16].
+            FunctionUart, PullNone: Gp16Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio16].
+            FunctionSpi, PullNone: Gp16Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio16].
+            FunctionI2C, PullUp: Gp16I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio16].
+            FunctionPwm, PullNone: Gp16Pwm0A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio16].
+            FunctionPio0, PullNone: Gp16Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio16].
+            FunctionPio1, PullNone: Gp16Pio1
+        }
+    },
+
+    /// GPIO 17 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp17Spi0Csn]        |
+    /// | `UART0 RX`   | [crate::Gp17Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp17I2C0Scl]        |
+    /// | `PWM0 B`     | [crate::Gp17Pwm0B]          |
+    /// | `PIO0`       | [crate::Gp17Pio0]           |
+    /// | `PIO1`       | [crate::Gp17Pio1]           |
+    Gpio17 {
+        name: gpio17,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio17].
+            FunctionUart, PullNone: Gp17Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio17].
+            FunctionSpi, PullNone: Gp17Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio17].
+            FunctionI2C, PullUp: Gp17I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio17].
+            FunctionPwm, PullNone: Gp17Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio0, PullNone: Gp17Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio1, PullNone: Gp17Pio1
+        }
+    },
+
+    /// GPIO 4 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp4Spi0Rx]          |
+    /// | `UART1 TX`   | [crate::Gp4Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp4I2C0Sda]         |
+    /// | `PWM2 A`     | [crate::Gp4Pwm2A]           |
+    /// | `PIO0`       | [crate::Gp4Pio0]            |
+    /// | `PIO1`       | [crate::Gp4Pio1]            |
     Gpio4 {
         name: gpio4,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio4].
+            FunctionUart, PullNone: Gp4Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio4].
+            FunctionSpi, PullNone: Gp4Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio4].
+            FunctionI2C, PullUp: Gp4I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio4].
+            FunctionPwm, PullNone: Gp4Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio0, PullNone: Gp4Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio1, PullNone: Gp4Pio1
+        }
     },
+
+    /// GPIO 5 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp5Spi0Csn]         |
+    /// | `UART1 RX`   | [crate::Gp5Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp5I2C0Scl]         |
+    /// | `PWM2 B`     | [crate::Gp5Pwm2B]           |
+    /// | `PIO0`       | [crate::Gp5Pio0]            |
+    /// | `PIO1`       | [crate::Gp5Pio1]            |
     Gpio5 {
         name: gpio5,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio5].
+            FunctionUart, PullNone: Gp5Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio5].
+            FunctionSpi, PullNone: Gp5Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio5].
+            FunctionI2C, PullUp: Gp5I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio5].
+            FunctionPwm, PullNone: Gp5Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio0, PullNone: Gp5Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio1, PullNone: Gp5Pio1
+        }
     },
+
+    /// GPIO 6 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp6Spi0Sck]         |
+    /// | `UART1 CTS`  | [crate::Gp6Uart1Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp6I2C1Sda]         |
+    /// | `PWM3 A`     | [crate::Gp6Pwm3A]           |
+    /// | `PIO0`       | [crate::Gp6Pio0]            |
+    /// | `PIO1`       | [crate::Gp6Pio1]            |
     Gpio6 {
         name: gpio6,
-    }
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio6].
+            FunctionUart, PullNone: Gp6Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio6].
+            FunctionSpi, PullNone: Gp6Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio6].
+            FunctionI2C, PullUp: Gp6I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio6].
+            FunctionPwm, PullNone: Gp6Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio0, PullNone: Gp6Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio1, PullNone: Gp6Pio1
+        }
+    },
+
+    /// GPIO 7 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp7Spi0Tx]          |
+    /// | `UART1 RTS`  | [crate::Gp7Uart1Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp7I2C1Scl]         |
+    /// | `PWM3 B`     | [crate::Gp7Pwm3B]           |
+    /// | `PIO0`       | [crate::Gp7Pio0]            |
+    /// | `PIO1`       | [crate::Gp7Pio1]            |
     Gpio7 {
         name: gpio7,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio7].
+            FunctionUart, PullNone: Gp7Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio7].
+            FunctionSpi, PullNone: Gp7Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio7].
+            FunctionI2C, PullUp: Gp7I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio7].
+            FunctionPwm, PullNone: Gp7Pwm3B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio0, PullNone: Gp7Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio1, PullNone: Gp7Pio1
+        }
     },
 
+    /// GPIO 8 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp8Spi1Rx]          |
+    /// | `UART1 TX`   | [crate::Gp8Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp8I2C0Sda]         |
+    /// | `PWM4 A`     | [crate::Gp8Pwm4A]           |
+    /// | `PIO0`       | [crate::Gp8Pio0]            |
+    /// | `PIO1`       | [crate::Gp8Pio1]            |
     Gpio8 {
         name: gpio8,
-        aliases: { FunctionUart, PullNone: Gp8Uart0Tx }
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio8].
+            FunctionUart, PullNone: Gp8Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio8].
+            FunctionSpi, PullNone: Gp8Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio8].
+            FunctionI2C, PullUp: Gp8I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio8].
+            FunctionPwm, PullNone: Gp8Pwm4A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio0, PullNone: Gp8Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio1, PullNone: Gp8Pio1
+        }
     },
+
+    /// GPIO 9 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp9Spi1Csn]         |
+    /// | `UART1 RX`   | [crate::Gp9Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp9I2C0Scl]         |
+    /// | `PWM4 B`     | [crate::Gp9Pwm4B]           |
+    /// | `PIO0`       | [crate::Gp9Pio0]            |
+    /// | `PIO1`       | [crate::Gp9Pio1]            |
     Gpio9 {
         name: gpio9,
-        aliases: { FunctionUart, PullNone: Gp9Uart0Rx}
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio9].
+            FunctionUart, PullNone: Gp9Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio9].
+            FunctionSpi, PullNone: Gp9Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio9].
+            FunctionI2C, PullUp: Gp9I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio9].
+            FunctionPwm, PullNone: Gp9Pwm4B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio0, PullNone: Gp9Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio1, PullNone: Gp9Pio1
+        }
     },
 
+    /// GPIO 29 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp29Spi1Csn]         |
+    /// | `UART0 RX`   | [crate::Gp29Uart0Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp29I2C0Scl]         |
+    /// | `PWM4 B`     | [crate::Gp29Pwm6B]           |
+    /// | `PIO0`       | [crate::Gp29Pio0]            |
+    /// | `PIO1`       | [crate::Gp29Pio1]            |
     Gpio29 {
         name: gpio29,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio29].
+            FunctionUart, PullNone: Gp29Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio29].
+            FunctionSpi, PullNone: Gp29Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio29].
+            FunctionI2C, PullUp: Gp29I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio29].
+            FunctionPwm, PullNone: Gp29Pwm6B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio29].
+            FunctionPio0, PullNone: Gp29Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio29].
+            FunctionPio1, PullNone: Gp29Pio1
+        }
     },
+
+    /// GPIO 28 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp28Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp28Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp28I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp28Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp28Pio0]           |
+    /// | `PIO1`       | [crate::Gp28Pio1]           |
     Gpio28 {
         name: gpio28,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio28].
+            FunctionUart, PullNone: Gp28Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio28].
+            FunctionSpi, PullNone: Gp28Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio28].
+            FunctionI2C, PullUp: Gp28I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio28].
+            FunctionPwm, PullNone: Gp28Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio0, PullNone: Gp28Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio1, PullNone: Gp28Pio1
+        }
     },
+
+    /// GPIO 27 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp27Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp27Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp27I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp27Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp27Pio0]           |
+    /// | `PIO1`       | [crate::Gp27Pio1]           |
     Gpio27 {
         name: gpio27,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio27].
+            FunctionUart, PullNone: Gp27Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio27].
+            FunctionSpi, PullNone: Gp27Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio27].
+            FunctionI2C, PullUp: Gp27I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio27].
+            FunctionPwm, PullNone: Gp27Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio0, PullNone: Gp27Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio1, PullNone: Gp27Pio1
+        }
     },
+
+    /// GPIO 26 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp26Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp26Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp26I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp26Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp26Pio0]           |
+    /// | `PIO1`       | [crate::Gp26Pio1]           |
     Gpio26 {
         name: gpio26,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio26].
+            FunctionUart, PullNone: Gp26Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio26].
+            FunctionSpi, PullNone: Gp26Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio26].
+            FunctionI2C, PullUp: Gp26I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio26].
+            FunctionPwm, PullNone: Gp26Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio0, PullNone: Gp26Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio1, PullNone: Gp26Pio1
+        }
     },
 
+    /// GPIO 22 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp22Spi0Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp22Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp22I2C1Sda]        |
+    /// | `PWM3 A`     | [crate::Gp22Pwm3A]          |
+    /// | `PIO0`       | [crate::Gp22Pio0]           |
+    /// | `PIO1`       | [crate::Gp22Pio1]           |
     Gpio22 {
         name: gpio22,
-        aliases: { FunctionSpi, PullNone: Gp22Spi0Sck }
-    },
-    Gpio20 {
-        name: gpio20,
-        aliases: { FunctionSpi, PullNone: Gp20Spi0Rx }
-    },
-    Gpio23 {
-        name: gpio23,
-        aliases: { FunctionSpi, PullNone: Gp23Spi0Tx }
-    },
-    Gpio21 {
-        name: gpio21,
-        aliases: { FunctionSpi, PullNone: Gp21Spi0Csn }
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio22].
+            FunctionUart, PullNone: Gp22Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio22].
+            FunctionSpi, PullNone: Gp22Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio22].
+            FunctionI2C, PullUp: Gp22I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio22].
+            FunctionPwm, PullNone: Gp22Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio0, PullNone: Gp22Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio1, PullNone: Gp22Pio1
+        }
     },
 
+    /// GPIO 20 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp20Spi0Rx]         |
+    /// | `UART1 TX`   | [crate::Gp20Uart1Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp20I2C0Sda]        |
+    /// | `PWM2 A`     | [crate::Gp20Pwm2A]          |
+    /// | `PIO0`       | [crate::Gp20Pio0]           |
+    /// | `PIO1`       | [crate::Gp20Pio1]           |
+    Gpio20 {
+        name: gpio20,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio20].
+            FunctionUart, PullNone: Gp20Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio20].
+            FunctionSpi, PullNone: Gp20Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio20].
+            FunctionI2C, PullUp: Gp20I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio20].
+            FunctionPwm, PullNone: Gp20Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio0, PullNone: Gp20Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio1, PullNone: Gp20Pio1
+        }
+    },
+
+    /// GPIO 23 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`   | [crate::Gp23Spi0Tx]        |
+    /// | `UART1 RTS`   | [crate::Gp23Uart1Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp23I2C1Scl]        |
+    /// | `PWM3 B`     | [crate::Gp23Pwm3B]          |
+    /// | `PIO0`       | [crate::Gp23Pio0]           |
+    /// | `PIO1`       | [crate::Gp23Pio1]           |
+    Gpio23 {
+        name: gpio23,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio21].
+            FunctionUart, PullNone: Gp23Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio21].
+            FunctionSpi, PullNone: Gp23Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio21].
+            FunctionI2C, PullUp: Gp23I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio21].
+            FunctionPwm, PullNone: Gp23Pwm3B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio0, PullNone: Gp23Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio1, PullNone: Gp23Pio1
+        }
+    },    
+
+    /// GPIO 21 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp21Spi0Csn]        |
+    /// | `UART1 RX`   | [crate::Gp21Uart1Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp21I2C0Scl]        |
+    /// | `PWM2 B`     | [crate::Gp21Pwm2B]          |
+    /// | `PIO0`       | [crate::Gp21Pio0]           |
+    /// | `PIO1`       | [crate::Gp21Pio1]           |
+    Gpio21 {
+        name: gpio21,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio21].
+            FunctionUart, PullNone: Gp21Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio21].
+            FunctionSpi, PullNone: Gp21Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio21].
+            FunctionI2C, PullUp: Gp21I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio21].
+            FunctionPwm, PullNone: Gp21Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio0, PullNone: Gp21Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio1, PullNone: Gp21Pio1
+        }
+    },    
+
+    /// GPIO 25 is connected to a neopixel on the top right of the board
     Gpio25 {
         name: neopixel,
     },

--- a/boards/boardsource-blok/src/lib.rs
+++ b/boards/boardsource-blok/src/lib.rs
@@ -494,7 +494,7 @@ hal::bsp_pins!(
             /// PIO1 Function alias for pin [crate::Pins::gpio21].
             FunctionPio1, PullNone: Gp23Pio1
         }
-    },    
+    },
 
     /// GPIO 21 supports following functions:
     ///
@@ -522,7 +522,7 @@ hal::bsp_pins!(
             /// PIO1 Function alias for pin [crate::Pins::gpio21].
             FunctionPio1, PullNone: Gp21Pio1
         }
-    },    
+    },
 
     /// GPIO 25 is connected to a neopixel on the top right of the board
     Gpio25 {


### PR DESCRIPTION
Updated boardsource_blok pinout according to the [pinout of the rp2040](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf#io-user-bank-function-table) and the information on [Peg](https://peg.software/docs/blok#main-pro-micro-pins).