### PR TITLE
Check all examples

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        features: ["", "--features rp2040-e5"]
+        features: ["--features rp2040-hal/rtic-monotonic", "--features rp2040-e5"]
         mode: ["", "--release"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           target: thumbv6m-none-eabi
           components: clippy
-      - run: cargo clippy --workspace --examples -- -Dwarnings
+      - run: cargo clippy --workspace --examples --features rp2040-hal/rtic-monotonic -- -Dwarnings

--- a/boards/rp-pico/examples/pico_rtic_monotonic.rs
+++ b/boards/rp-pico/examples/pico_rtic_monotonic.rs
@@ -21,7 +21,11 @@ mod app {
 
     #[shared]
     struct Shared {
-        led: hal::gpio::Pin<hal::gpio::pin::bank0::Gpio25, hal::gpio::PushPullOutput>,
+        led: hal::gpio::Pin<
+            hal::gpio::bank0::Gpio25,
+            hal::gpio::FunctionSioOutput,
+            hal::gpio::PullNone,
+        >,
     }
 
     #[monotonic(binds = TIMER_IRQ_0, default = true)]
@@ -39,7 +43,7 @@ mod app {
         }
         let mut resets = c.device.RESETS;
         let mut watchdog = Watchdog::new(c.device.WATCHDOG);
-        let _clocks = init_clocks_and_plls(
+        let clocks = init_clocks_and_plls(
             XOSC_CRYSTAL_FREQ,
             c.device.XOSC,
             c.device.CLOCKS,
@@ -58,10 +62,10 @@ mod app {
             sio.gpio_bank0,
             &mut resets,
         );
-        let mut led = pins.led.into_push_pull_output();
+        let mut led = pins.led.reconfigure();
         led.set_low().unwrap();
 
-        let mut timer = hal::Timer::new(c.device.TIMER, &mut resets);
+        let mut timer = hal::Timer::new(c.device.TIMER, &mut resets, &clocks);
         let alarm = timer.alarm_0().unwrap();
         blink_led::spawn_after(500.millis()).unwrap();
 


### PR DESCRIPTION
The example pico_rtic_monotonic depends on the feature rp2040-hal/rtic-monotonic. Therefore it wasn't built by CI, so it wasn't noticed that the example was actually broken.