### PR TITLE
Feature/deprecated runner in cargo config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -39,4 +39,4 @@ runner = "elf2uf2-rs -d"
 
 # This runner will find a supported SWD debug probe and flash your RP2040 over
 # SWD:
-# runner = "probe-run --chip RP2040"
+# runner = ""probe-rs run --chip RP2040""

--- a/.cargo/config
+++ b/.cargo/config
@@ -39,4 +39,4 @@ runner = "elf2uf2-rs -d"
 
 # This runner will find a supported SWD debug probe and flash your RP2040 over
 # SWD:
-# runner = ""probe-rs run --chip RP2040""
+# runner = "probe-rs run --chip RP2040"


### PR DESCRIPTION
Using the repo I found that I had to install probe-run, which itselfs complains about being deprecated.