### PR TITLE
Release preparation for all BSPs w/ rp2040-hal 0.10

### DIFF
--- a/boards/adafruit-feather-rp2040/CHANGELOG.md
+++ b/boards/adafruit-feather-rp2040/CHANGELOG.md
@@ -11,13 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
+- Update to rp2040-hal 0.10.0
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/adafruit-feather-rp2040/CHANGELOG.md
+++ b/boards/adafruit-feather-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-feather-rp2040"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Andrea Nall <anall@andreanal.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-feather-rp2040"

--- a/boards/adafruit-feather-rp2040/README.md
+++ b/boards/adafruit-feather-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Feather.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-feather-rp2040 = "0.6.0"
+adafruit-feather-rp2040 = "0.8.0"
 ```
 
 In your program, you will need to call `adafruit_feather_rp2040::Pins::new` to create

--- a/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
@@ -11,13 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
+- Update to rp2040-hal 0.10.0
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-itsy-bitsy-rp2040"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit_itsy_bitsy_rp2040"

--- a/boards/adafruit-itsy-bitsy-rp2040/README.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the ItsyBitsy RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-itsy-bitsy-rp2040 = "0.6.0"
+adafruit-itsy-bitsy-rp2040 = "0.8.0"
 ```
 
 In your program, you will need to call `adafruit_itsy_bitsy_rp2040::Pins::new` to create

--- a/boards/adafruit-kb2040/CHANGELOG.md
+++ b/boards/adafruit-kb2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/adafruit-kb2040/CHANGELOG.md
+++ b/boards/adafruit-kb2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-kb2040"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-kb2040"

--- a/boards/adafruit-kb2040/README.md
+++ b/boards/adafruit-kb2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the KB2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-kb2040 = "0.6.0"
+adafruit-kb2040 = "0.8.0"
 ```
 
 In your program, you will need to call `adafruit-kb2040::Pins::new` to create

--- a/boards/adafruit-macropad/CHANGELOG.md
+++ b/boards/adafruit-macropad/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/adafruit-macropad/CHANGELOG.md
+++ b/boards/adafruit-macropad/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-macropad"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Andrea Nall <anall@andreanal.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit_macropad"

--- a/boards/adafruit-macropad/README.md
+++ b/boards/adafruit-macropad/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Feather.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-macropad = "0.6.0"
+adafruit-macropad = "0.8.0"
 ```
 
 In your program, you will need to call `adafruit_macropad::Pins::new` to create

--- a/boards/adafruit-metro-rp2040/CHANGELOG.md
+++ b/boards/adafruit-metro-rp2040/CHANGELOG.md
@@ -7,4 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.0 - 2024-04-07
+
 - Initial release

--- a/boards/adafruit-qt-py-rp2040/CHANGELOG.md
+++ b/boards/adafruit-qt-py-rp2040/CHANGELOG.md
@@ -13,11 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update to rp2040-hal 0.10.0
 - Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/adafruit-qt-py-rp2040/CHANGELOG.md
+++ b/boards/adafruit-qt-py-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-qt-py-rp2040"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Stephen Onnen <stephen.onnen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-qt-py-rp2040"

--- a/boards/adafruit-qt-py-rp2040/README.md
+++ b/boards/adafruit-qt-py-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the QT Py.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-qt-py-rp2040 = "0.6.0"
+adafruit-qt-py-rp2040 = "0.8.0"
 ```
 
 In your program, you will need to call `adafruit_qt_py_rp2040::Pins::new` to create

--- a/boards/adafruit-trinkey-qt2040/CHANGELOG.md
+++ b/boards/adafruit-trinkey-qt2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.6.0 - 2023-09-02
 

--- a/boards/adafruit-trinkey-qt2040/CHANGELOG.md
+++ b/boards/adafruit-trinkey-qt2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.6.0 - 2023-09-02
 
 ### Changed

--- a/boards/adafruit-trinkey-qt2040/Cargo.toml
+++ b/boards/adafruit-trinkey-qt2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-trinkey-qt2040"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-trinkey-qt2040"

--- a/boards/adafruit-trinkey-qt2040/README.md
+++ b/boards/adafruit-trinkey-qt2040/README.md
@@ -15,7 +15,7 @@ RP2040 chip according to how it is connected up on the Trinkey.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-trinkey-qt2040 = "0.5.0"
+adafruit-trinkey-qt2040 = "0.7.0"
 ```
 
 In your program, you will need to call `adafruit-trinkey-qt2040::Pins::new` to create

--- a/boards/arduino_nano_connect/CHANGELOG.md
+++ b/boards/arduino_nano_connect/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.6.0 - 2023-09-02
 

--- a/boards/arduino_nano_connect/CHANGELOG.md
+++ b/boards/arduino_nano_connect/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.6.0 - 2023-09-02
 
 ### Changed

--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_nano_connect"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["splicedbread <dxbunrated@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/arduino_nano_connect"

--- a/boards/arduino_nano_connect/README.md
+++ b/boards/arduino_nano_connect/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the nano connect.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-arduino_nano_connect = "0.5.0"
+arduino_nano_connect = "0.7.0"
 ```
 # TODO - down and out
 In your program, you will need to call `arduino_nano_connect::Pins::new` to create

--- a/boards/boardsource-blok/CHANGELOG.md
+++ b/boards/boardsource-blok/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.3.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.2.1 - 2023-10-25
 
 ### Changed

--- a/boards/boardsource-blok/CHANGELOG.md
+++ b/boards/boardsource-blok/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.2.1 - 2023-10-25
 

--- a/boards/boardsource-blok/Cargo.toml
+++ b/boards/boardsource-blok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boardsource-blok"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Agent59 <agent59@ripakewitz.net>", "The rp-rs Developers"]
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/boardsource-blok"

--- a/boards/boardsource-blok/README.md
+++ b/boards/boardsource-blok/README.md
@@ -18,7 +18,7 @@ More Information about the pin layout at [Peg].
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-boardsource-blok = "0.1.0"
+boardsource-blok = "0.3.0"
 ```
 
 In your program, you will need to call `blok::Pins::new` to create

--- a/boards/pimoroni-pico-explorer/CHANGELOG.md
+++ b/boards/pimoroni-pico-explorer/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/pimoroni-pico-explorer/CHANGELOG.md
+++ b/boards/pimoroni-pico-explorer/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-pico-explorer"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Hmvp <hmvp@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-pico-explorer"

--- a/boards/pimoroni-pico-explorer/README.md
+++ b/boards/pimoroni-pico-explorer/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Pico Explorer.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-pico-explorer = "0.6.0"
+pimoroni-pico-explorer = "0.8.0"
 ```
 
 In your program, you will need to call `pimoroni_pico_explorer::Pins::new` to create

--- a/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
+++ b/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
+++ b/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/pimoroni-pico-lipo-16mb/Cargo.toml
+++ b/boards/pimoroni-pico-lipo-16mb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-pico-lipo-16mb"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Hmvp <hmvp@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-pico-lipo-16mb"

--- a/boards/pimoroni-pico-lipo-16mb/README.md
+++ b/boards/pimoroni-pico-lipo-16mb/README.md
@@ -18,7 +18,7 @@ space, and so it may not work if you only have the 4MB variant.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-pico-lipo-16mb = "0.6.0"
+pimoroni-pico-lipo-16mb = "0.8.0"
 ```
 
 In your program, you will need to call `pimoroni_pico_lipo_16mb::Pins::new` to create

--- a/boards/pimoroni-plasma-2040/CHANGELOG.md
+++ b/boards/pimoroni-plasma-2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.6.0 - 2023-09-02
 

--- a/boards/pimoroni-plasma-2040/CHANGELOG.md
+++ b/boards/pimoroni-plasma-2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.6.0 - 2023-09-02
 
 ### Changed

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-plasma-2040"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Jordan Williams <jordan@jwillikers.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-plasma-2040"

--- a/boards/pimoroni-plasma-2040/README.md
+++ b/boards/pimoroni-plasma-2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Pimoroni Plasma 2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-plasma-2040 = "0.5.0"
+pimoroni-plasma-2040 = "0.7.0"
 ```
 
 In your program, you will need to call `pimoroni_plasma_2040::Pins::new` to create

--- a/boards/pimoroni-servo2040/CHANGELOG.md
+++ b/boards/pimoroni-servo2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.5.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.4.0 - 2023-09-02
 
 ### Changed

--- a/boards/pimoroni-servo2040/CHANGELOG.md
+++ b/boards/pimoroni-servo2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.4.0 - 2023-09-02
 

--- a/boards/pimoroni-servo2040/Cargo.toml
+++ b/boards/pimoroni-servo2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-servo2040"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Paul Daniel Faria <nashenas88@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-servo2040"

--- a/boards/pimoroni-servo2040/README.md
+++ b/boards/pimoroni-servo2040/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Servo2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-servo2040 = "0.3.0"
+pimoroni-servo2040 = "0.5.0"
 ```
 
 In your program, you will need to call `pimoroni_servo2040::Pins::new` to create

--- a/boards/pimoroni-tiny2040/CHANGELOG.md
+++ b/boards/pimoroni-tiny2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.6.0 - 2023-09-02
 

--- a/boards/pimoroni-tiny2040/CHANGELOG.md
+++ b/boards/pimoroni-tiny2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.6.0 - 2023-09-02
 
 ### Changed

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-tiny2040"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Mike Bell <mdb036@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-tiny2040"

--- a/boards/pimoroni-tiny2040/README.md
+++ b/boards/pimoroni-tiny2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Tiny2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-tiny2040 = "0.5.0"
+pimoroni-tiny2040 = "0.7.0"
 ```
 
 In your program, you will need to call `pimoroni_tiny2040::Pins::new` to create

--- a/boards/pimoroni-tufty2040/CHANGELOG.md
+++ b/boards/pimoroni-tufty2040/CHANGELOG.md
@@ -6,3 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 0.1.0 - 2024-04-07
+Initial release

--- a/boards/pimoroni_badger2040/CHANGELOG.md
+++ b/boards/pimoroni_badger2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.5.0 - 2023-09-02
 

--- a/boards/pimoroni_badger2040/CHANGELOG.md
+++ b/boards/pimoroni_badger2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.5.0 - 2023-09-02
 
 ### Changed

--- a/boards/pimoroni_badger2040/Cargo.toml
+++ b/boards/pimoroni_badger2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni_badger2040"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["9names", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni_badger2040"

--- a/boards/pimoroni_badger2040/README.md
+++ b/boards/pimoroni_badger2040/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Badger2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni_badger2040 = "0.4.0"
+pimoroni_badger2040 = "0.6.0"
 ```
 
 In your program, you will need to call `pimoroni_badger2040::Board::take().unwrap()` to create

--- a/boards/rp-pico/CHANGELOG.md
+++ b/boards/rp-pico/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.9.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.8.0 - 2023-09-02
 
 ### Changed

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp-pico"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["evan <evanmolder@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/rp-pico"

--- a/boards/rp-pico/README.md
+++ b/boards/rp-pico/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Pico.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-rp-pico = "0.7.0"
+rp-pico = "0.9.0"
 ```
 
 In your program, you will need to call `rp_pico::Pins::new` to create

--- a/boards/seeeduino-xiao-rp2040/CHANGELOG.md
+++ b/boards/seeeduino-xiao-rp2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.5.0 - 2023-09-02
 

--- a/boards/seeeduino-xiao-rp2040/CHANGELOG.md
+++ b/boards/seeeduino-xiao-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.5.0 - 2023-09-02
 
 ### Changed

--- a/boards/seeeduino-xiao-rp2040/Cargo.toml
+++ b/boards/seeeduino-xiao-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seeeduino-xiao-rp2040"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Philip L. McMahon <plm@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/seeeduino-xiao-rp02040"

--- a/boards/seeeduino-xiao-rp2040/README.md
+++ b/boards/seeeduino-xiao-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the XIAO RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-seeeduino-xiao-rp2040 = "0.4.0"
+seeeduino-xiao-rp2040 = "0.6.0"
 ```
 
 In your program, you will need to call `seeeduino-xiao-rp2040::Pins::new` to create

--- a/boards/solderparty-rp2040-stamp/CHANGELOG.md
+++ b/boards/solderparty-rp2040-stamp/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.6.0 - 2023-09-02
 

--- a/boards/solderparty-rp2040-stamp/CHANGELOG.md
+++ b/boards/solderparty-rp2040-stamp/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.6.0 - 2023-09-02
 
 ### Changed

--- a/boards/solderparty-rp2040-stamp/Cargo.toml
+++ b/boards/solderparty-rp2040-stamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solderparty-rp2040-stamp"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/solderparty-rp2040-stamp"

--- a/boards/solderparty-rp2040-stamp/README.md
+++ b/boards/solderparty-rp2040-stamp/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Stamp
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-solderparty-rp2040-stamp = "0.5.0"
+solderparty-rp2040-stamp = "0.7.0"
 ```
 
 In your program, you will need to call `solderparty_rp2040_stamp::Pins::new` to create

--- a/boards/sparkfun-micromod-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-micromod-rp2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.1.1 - 2023-06-22
 

--- a/boards/sparkfun-micromod-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-micromod-rp2040/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## 0.3.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.1.1 - 2023-06-22
 
 - Improve README and Documentation

--- a/boards/sparkfun-micromod-rp2040/Cargo.toml
+++ b/boards/sparkfun-micromod-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkfun-micromod-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Finomnis <finomnis@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/sparkfun-micromod-rp2040"

--- a/boards/sparkfun-micromod-rp2040/README.md
+++ b/boards/sparkfun-micromod-rp2040/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the MicroMod RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-sparkfun-micromod-rp2040 = "0.1.0"
+sparkfun-micromod-rp2040 = "0.3.0"
 ```
 
 In your program, you will need to call `sparkfun_micromod_rp2040::Pins::new` to create

--- a/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkfun-pro-micro-rp2040"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/sparkfun-pro-micro-rp2040"

--- a/boards/sparkfun-pro-micro-rp2040/README.md
+++ b/boards/sparkfun-pro-micro-rp2040/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Pro Micro RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-sparkfun-pro-micro-rp2040 = "0.6.0"
+sparkfun-pro-micro-rp2040 = "0.8.0"
 ```
 
 In your program, you will need to call `sparkfun_pro_micro_rp2040::Pins::new` to create

--- a/boards/sparkfun-thing-plus-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-thing-plus-rp2040/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.6.0 - 2023-09-02
 

--- a/boards/sparkfun-thing-plus-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-thing-plus-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.6.0 - 2023-09-02
 
 ### Changed

--- a/boards/sparkfun-thing-plus-rp2040/Cargo.toml
+++ b/boards/sparkfun-thing-plus-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkfun-thing-plus-rp2040"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Tyler Pottenger <tyler.pottenger@gmail.com>", "Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/sparkfun-thing-plus-rp2040"

--- a/boards/sparkfun-thing-plus-rp2040/README.md
+++ b/boards/sparkfun-thing-plus-rp2040/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Thing Plus RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-sparkfun-thing-plus-rp2040 = "0.5.0"
+sparkfun-thing-plus-rp2040 = "0.7.0"
 ```
 
 In your program, you will need to call `sparkfun_thing_plus_rp2040::Pins::new` to create

--- a/boards/vcc-gnd-yd-rp2040/CHANGELOG.md
+++ b/boards/vcc-gnd-yd-rp2040/CHANGELOG.md
@@ -12,12 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
+- Update to usb-device 0.3
 
 ## 0.5.0 - 2023-09-02
 

--- a/boards/vcc-gnd-yd-rp2040/CHANGELOG.md
+++ b/boards/vcc-gnd-yd-rp2040/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.6.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.5.0 - 2023-09-02
 
 ### Changed

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vcc-gnd-yd-rp2040"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Nicolas <nleguen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/vcc-gnd-yd-rp2040"

--- a/boards/vcc-gnd-yd-rp2040/README.md
+++ b/boards/vcc-gnd-yd-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the YD-RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-vcc-gnd-yd-rp2040 = "0.4.0"
+vcc-gnd-yd-rp2040 = "0.6.0"
 ```
 
 In your program, you will need to call `vcc_gnd_studio_yd_rp2040::Pins::new` to create

--- a/boards/waveshare-rp2040-lcd-0-96/CHANGELOG.md
+++ b/boards/waveshare-rp2040-lcd-0-96/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/waveshare-rp2040-lcd-0-96/CHANGELOG.md
+++ b/boards/waveshare-rp2040-lcd-0-96/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/waveshare-rp2040-lcd-0-96/Cargo.toml
+++ b/boards/waveshare-rp2040-lcd-0-96/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waveshare-rp2040-lcd-0-96"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["René van Dorst <opensource@vdorst.com>", "Andrea Nall <anall@andreanal.com>", "TilCreator <contact.github@tc-j.de>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/waveshare-rp2040-lcd-0_96"

--- a/boards/waveshare-rp2040-lcd-0-96/README.md
+++ b/boards/waveshare-rp2040-lcd-0-96/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Feather.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-waveshare_rp2040_lcd_0_96 = "0.6.0"
+waveshare_rp2040_lcd_0_96 = "0.8.0"
 ```
 
 In your program, you will need to call `waveshare_rp2040_lcd_0_96::Pins::new` to create

--- a/boards/waveshare-rp2040-zero/CHANGELOG.md
+++ b/boards/waveshare-rp2040-zero/CHANGELOG.md
@@ -12,12 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to rp2040-hal 0.10.0
-- Update to ws2812-pio 0.8.0
-- Update to i2c-pio 0.8.0
-- Update to embedded-sdmmc 0.5.0
 - Update to embedded-hal 1.0.0
-- Update to usbd-hid 0.7.0
-- Update to usbd-serial 0.2.1
 
 ## 0.7.0 - 2023-09-02
 

--- a/boards/waveshare-rp2040-zero/CHANGELOG.md
+++ b/boards/waveshare-rp2040-zero/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.8.0 - 2024-04-07
+
+### Changed
+
+- Update to rp2040-hal 0.10.0
+- Update to ws2812-pio 0.8.0
+- Update to i2c-pio 0.8.0
+- Update to embedded-sdmmc 0.5.0
+- Update to embedded-hal 1.0.0
+- Update to usbd-hid 0.7.0
+- Update to usbd-serial 0.2.1
+
 ## 0.7.0 - 2023-09-02
 
 ### Changed

--- a/boards/waveshare-rp2040-zero/Cargo.toml
+++ b/boards/waveshare-rp2040-zero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waveshare-rp2040-zero"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Andrea Nall <anall@andreanal.com>", "TilCreator <contact.github@tc-j.de>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/waveshare-rp2040-zero"

--- a/boards/waveshare-rp2040-zero/README.md
+++ b/boards/waveshare-rp2040-zero/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Feather.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-waveshare-rp2040-zero = "0.6.0"
+waveshare-rp2040-zero = "0.8.0"
 ```
 
 In your program, you will need to call `waveshare_rp2040_zero::Pins::new` to create


### PR DESCRIPTION
Bumped all crate version numbers (for published BSPs).
Added changelog entry for each BSP.

In the changelog for all non-pico boards, I'm only listing dependency changes for *direct* dependencies.
No-one should care that a dependency used by an example has changed.

Once again, most of the time preparing this release was spent writing change logs that I don't think anyone will ever read.