### PR TITLE
Fixes board name in comments, adds main() documentation

### DIFF
--- a/boards/waveshare-rp2040-zero/examples/waveshare_rp2040_zero_neopixel_rainbow.rs
+++ b/boards/waveshare-rp2040-zero/examples/waveshare_rp2040_zero_neopixel_rainbow.rs
@@ -1,6 +1,6 @@
-//! Rainbow effect color wheel using the onboard NeoPixel on an Waveshare RP2040 Zero board
+//! Rainbow effect color wheel using the onboard NeoPixel on an Waveshare RP2040-Zero board
 //!
-//! This flows smoothly through various colors on the onboard NeoPixel.
+//! This flows smoothly through various colours on the onboard NeoPixel.
 //! Uses the `ws2812_pio` driver to control the NeoPixel, which in turns uses the
 //! RP2040's PIO block.
 #![no_std]
@@ -24,6 +24,13 @@ use waveshare_rp2040_zero::{
 };
 use ws2812_pio::Ws2812;
 
+/// Entry point to our bare-metal application.
+///
+/// The `#[entry]` macro ensures the Cortex-M start-up code calls this function
+/// as soon as all global variables are initialised.
+///
+/// The function configures the RP2040 peripherals, then infinitely cycles the built-in LED colour from red, to green,
+/// to blue and back to red.
 #[entry]
 fn main() -> ! {
     let mut pac = pac::Peripherals::take().unwrap();
@@ -55,7 +62,7 @@ fn main() -> ! {
     // Configure the addressable LED
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
-        // The onboard NeoPixel is attached to GPIO pin #16 on the Feather RP2040.
+        // The onboard NeoPixel is attached to GPIO pin #16 on the Waveshare RP2040-Zero.
         pins.neopixel.into_function(),
         &mut pio,
         sm0,


### PR DESCRIPTION
Noticed that the board name was incorrect in one of the comments, changed it to prevent confusion. Also added modified function documentation for the `main` function, modified from the Rpi Pico examples.