### PR TITLE
add BSP for Pimoroni Interstate 75

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "boards/arduino_nano_connect",
     "boards/boardsource-blok",
     "boards/pimoroni_badger2040",
+    "boards/pimoroni-interstate75",
     "boards/pimoroni-pico-explorer",
     "boards/pimoroni-pico-lipo-16mb",
     "boards/pimoroni-plasma-2040",

--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ RP2040 chip according to how it is connected up on the Badger2040.
 [Pimoroni Badger2040]: https://shop.pimoroni.com/products/badger-2040
 [pimoroni_badger2040]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni_badger2040
 
+### [pimoroni-interstate75] - Board Support for the [Pimoroni Interstate 75]
+
+You should include this crate if you are writing code that you want to run on
+a [Pimoroni Interstate 75] - An RGB LED matrix driver board.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Interstate 75.
+
+[Pimoroni Interstate 75]: https://shop.pimoroni.com/products/interstate-75
+[pimoroni-interstate75]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni_interstate75
+
 ### [pimoroni-pico-explorer] - Board Support for the [Pimoroni Pico Explorer]
 
 You should include this crate if you are writing code that you want to run on

--- a/boards/pimoroni-interstate75/CHANGELOG.md
+++ b/boards/pimoroni-interstate75/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- New BSP for Pimoroni Interstate 75

--- a/boards/pimoroni-interstate75/Cargo.toml
+++ b/boards/pimoroni-interstate75/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "pimoroni-interstate75"
+version = "0.1.0"
+authors = ["Eric Seppanen <eds@reric.net>", "The rp-rs Developers"]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-interstate75"
+description = "Board Support Package for the Pimoroni Interstate 75"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rp-rs/rp-hal-boards.git"
+
+[dependencies]
+cortex-m.workspace = true
+cortex-m-rt = { workspace = true, optional = true }
+rp2040-boot2 = { workspace = true, optional = true }
+rp2040-hal.workspace = true
+
+[dev-dependencies]
+embedded-hal.workspace = true
+fugit.workspace = true
+panic-halt.workspace = true
+rp2040-hal = { workspace = true, features = [ "defmt" ]  }
+
+defmt.workspace = true
+defmt-rtt.workspace = true
+
+[features]
+# This is the set of features we enable by default
+default = ["boot2", "rt", "critical-section-impl", "rom-func-cache"]
+
+# critical section that is safe for multicore use
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
+
+# 2nd stage bootloaders for rp2040
+boot2 = ["rp2040-boot2"]
+
+# Minimal startup / runtime for Cortex-M microcontrollers
+rt = ["cortex-m-rt","rp2040-hal/rt"]
+
+# This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
+# Only required for RP2040 B0 and RP2040 B1, but it also works for RP2040 B2 and above
+rp2040-e5 = ["rp2040-hal/rp2040-e5"]
+
+# Memoize(cache) ROM function pointers on first use to improve performance
+rom-func-cache = ["rp2040-hal/rom-func-cache"]
+
+# Disable automatic mapping of language features (like floating point math) to ROM functions
+disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
+
+# This enables ROM functions for f64 math that were not present in the earliest RP2040s
+rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]

--- a/boards/pimoroni-interstate75/README.md
+++ b/boards/pimoroni-interstate75/README.md
@@ -1,0 +1,95 @@
+# [pimoroni-interstate75] - Board Support for the [Pimoroni Interstate 75]
+
+You should include this crate if you are writing code that you want to run on
+a [Pimoroni Interstate 75] - an LED matrix driver board based on the RP2040.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Tiny2040.
+
+[Pimoroni Interstate 75]: https://shop.pimoroni.com/products/interstate-75
+[pimoroni-interstate75]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni_interstate75
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+[Raspberry Silicon RP2040]: https://www.raspberrypi.org/products/rp2040/
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+pimoroni-interstate75 = "0.1.0"
+```
+
+In your program, you will need to call `pimoroni_interstate75::Pins::new` to create
+a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal-boards_ repository and run:
+
+```console
+rp-hal-boards/boards/pimoroni-interstate75 $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal-boards/boards/pimoroni-interstate75 $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs
+```
+then try repeating the `cargo run` command above.
+
+### [interstate75_blinky](./examples/interstate75_blinky.rs)
+
+Flashes the I75's three on-board LEDs in sequence.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can choose either the MIT license or the
+Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific license.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/pimoroni-interstate75/build.rs
+++ b/boards/pimoroni-interstate75/build.rs
@@ -1,0 +1,6 @@
+//! This build script makes sure the linker flag -Tdefmt.x is added
+//! for the examples.
+
+fn main() {
+    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
+}

--- a/boards/pimoroni-interstate75/examples/interstate75_blinky.rs
+++ b/boards/pimoroni-interstate75/examples/interstate75_blinky.rs
@@ -1,0 +1,67 @@
+//! Blinks the RGB LEDs on an Interstate 75 in sequence
+#![no_std]
+#![no_main]
+
+use bsp::entry;
+use defmt::*;
+use defmt_rtt as _;
+use embedded_hal::digital::OutputPin;
+use panic_halt as _;
+
+use pimoroni_interstate75 as bsp;
+
+use bsp::hal::{
+    clocks::{init_clocks_and_plls, Clock},
+    pac,
+    sio::Sio,
+    watchdog::Watchdog,
+};
+
+#[entry]
+fn main() -> ! {
+    info!("Program start");
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+    let sio = Sio::new(pac.SIO);
+
+    let clocks = init_clocks_and_plls(
+        bsp::XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    let pins = bsp::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let mut led_red = pins.led_r.into_push_pull_output();
+    let mut led_green = pins.led_g.into_push_pull_output();
+    let mut led_blue = pins.led_b.into_push_pull_output();
+    led_red.set_high().unwrap();
+    led_green.set_high().unwrap();
+    led_blue.set_high().unwrap();
+
+    loop {
+        led_green.set_low().unwrap();
+        delay.delay_ms(500);
+        led_green.set_high().unwrap();
+        led_blue.set_low().unwrap();
+        delay.delay_ms(500);
+        led_blue.set_high().unwrap();
+        led_red.set_low().unwrap();
+        delay.delay_ms(500);
+        led_red.set_high().unwrap();
+    }
+}

--- a/boards/pimoroni-interstate75/src/lib.rs
+++ b/boards/pimoroni-interstate75/src/lib.rs
@@ -1,0 +1,108 @@
+//! Board support package for the Pimoroni Interstate 75.
+//!
+//! Pin names follow the Interstate 75 schematic dated 08/12/2021.
+//!
+//! <https://shop.pimoroni.com/products/interstate-75>
+//!
+//! There are a few pin names that may cause confusion; for example `user_sw` is
+//! connected to a button labeled "BOOT", and `ADC0..2` are connected to the expansion
+//! header, so they may be used for any purpose.
+//!
+//! `led_r`, `led_g`, and `leg_b` pins are connected to the RGB LED on the Interstate 75
+//! board; they are unrelated to the HUB75 connector so they can be used for anything.
+//! Note these pins are active-low.
+//!
+//! Many devices number the HUB75 pins R1,G1,B1,R2,G2,B2.
+//! This crate follows the labels on the Interstate 75 schematic: R0,G0,B0,R1,G1,B1.
+//! If you need to connect to a device with different numbering, just treat
+//! `bsp::Pins::r0` as "R1" and `bsp::Pins::r1` as "R2", etc.
+
+#![no_std]
+
+pub use hal::pac;
+pub use rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+pub use rp2040_hal::entry;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+hal::bsp_pins!(
+    /// HUB75 interface, first red channel.
+    Gpio0 { name: r0 },
+    /// HUB75 interface, first green channel.
+    Gpio1 { name: g0 },
+    /// HUB75 interface, first blue channel.
+    Gpio2 { name: b0 },
+    /// HUB75 interface, second red channel.
+    Gpio3 { name: r1 },
+    /// HUB75 interface, second green channel.
+    Gpio4 { name: g1 },
+    /// HUB75 interface, second blue channel.
+    Gpio5 { name: b1 },
+    /// HUB75 interface, row address A.
+    Gpio6 { name: row_a },
+    /// HUB75 interface, row address B.
+    Gpio7 { name: row_b },
+    /// HUB75 interface, row address C.
+    Gpio8 { name: row_c },
+    /// HUB75 interface, row address D.
+    Gpio9 { name: row_d },
+    /// HUB75E interface, row address E.
+    Gpio10 { name: row_e },
+    /// HUB75 interface, clock.
+    Gpio11 { name: led_clk },
+    /// HUB75 interface, latch.
+    Gpio12 { name: led_stb },
+    /// HUB75 interface, OE#, aka LAT.
+    Gpio13 { name: led_oe },
+
+    /// Interstate 75 button A.
+    Gpio14 { name: sw_a },
+
+    //Gpio15 { name: gpio15 }, // not connected
+
+    /// RGB LED Red on Interstate 75 PCB. Active low.
+    Gpio16 { name: led_r },
+    /// RGB LED Green on Interstate 75 PCB. Active low.
+    Gpio17 { name: led_g },
+    /// RGB LED Blue on Interstate 75 PCB. Active low.
+    Gpio18 { name: led_b },
+
+    // FIXME: add aliases for other functions for expansion header pins.
+
+    /// I2C_INT pin on the expansion header.
+    Gpio19 { name: i2c_int },
+    /// I2C_SDA pin on the expansion header.
+    Gpio20 { name: i2c_sda },
+    /// I2C_SCL pin on the expansion header.
+    Gpio21 { name: i2c_scl },
+
+    //Gpio22 { name: gpio22 }, // not connected
+
+    /// Interstate 75 BOOT / user switch.
+    Gpio23 { name: user_sw },
+
+    // Gpio24 { name: gpio24 }, // not connected
+    // Gpio25 { name: gpio25 }, // not connected
+
+    // FIXME: add aliases for other functions for expansion header pins.
+
+    /// GPIO26 (ADC0 pin on the expansion header).
+    Gpio26 { name: adc0 },
+    /// GPIO27 (ADC1 pin on the expansion header).
+    Gpio27 { name: adc1 },
+    /// GPIO28 (ADC2 pin on the expansion header).
+    Gpio28 { name: adc2 },
+
+    /// GPIO29 (current sense circuit on the Interstate 75).
+    Gpio29 { name: adc3 },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
This adds a bsp crate for the [Pimoroni Interstate 75](https://shop.pimoroni.com/products/interstate-75).

I used the pin names from the [schematic](https://cdn.shopify.com/s/files/1/0174/1800/files/interstate_75_schematic.pdf?v=1638972894). In some cases the names are odd or ambiguous; I chose to keep the schematic names rather than adjust things. Confusing names are documented in `lib.rs`.

I have verified that the onboard RGB LED works with the included example. I also verified the HUB75 LED matrix pins work, using a fork of `hub75-pio`. I have not verified the expansion header pins or the current sense input.

I'm not confident I understand the details of the `bsp_pins!` macro, so I haven't added any pin function aliases. Advice on how to do this properly would be welcome!

For example, would it be a good idea to add a PWM function for the onboard RGB LED pins?

Should I do anything special for hardwired button input pins? `sw_a` is a switch to ground with no current-limiting or pullup/pulldown resistors, so I think the only correct configuration is as an input with internal pull-up. Can I enforce this?

Similarly, GPIO29 is connected to an opamp output, so I think the only correct pin configuration is as a high-impedance ADC input.

The board also has some expansion pins for the user (and aren't connected to anything onboard); should I add function aliases for:
- GPIO19..21 (connected to the expansion header and labeled I2C_INT, I2C_SDA, I2C_SCL)?
- GPIO26..28 (connected to the expansion header with names ADC0..2)?
