### PR TITLE
Bulk update of docs mentioning .cargo/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ More details can be found in the [Project Template](https://github.com/rp-rs/rp2
 $ cargo install elf2uf2-rs --locked
 ```
 
-*Step 2* - Make sure your .cargo/config contains the following (it should by
+*Step 2* - Make sure your .cargo/config.toml contains the following (it should by
 default if you are working in this repository):
 
 ```toml
@@ -433,7 +433,7 @@ $ cargo install --locked probe-rs-tools
 
 Alternatively, follow the installation instructions on https://probe.rs/.
 
-*Step 2* - Make sure your .cargo/config contains the following:
+*Step 2* - Make sure your .cargo/config.toml contains the following:
 
 ```toml
 [target.thumbv6m-none-eabi]

--- a/boards/boardsource-blok/README.md
+++ b/boards/boardsource-blok/README.md
@@ -62,7 +62,7 @@ To start a basic project from scratch, create a project using `cargo new project
 project directory, run `cargo add blok`, `cargo add cortex-m-rt`, and `cargo add panic-halt`. The
 first command will add this HAL (Hardware Abstraction Layer), the second is required for the `#[entry]` macro, and _panic-halt_ creates a simple panic function, which just halts.
 
-You'll also need to copy the cargo config file from the [repo](https://github.com/rp-rs/rp-hal-boards/blob/main/.cargo/config). It specifies the target and optimizing flags to the linker. You'll also need to copy [_memory.x_](https://github.com/rp-rs/rp-hal-boards/blob/main/memory.x) to your project root. This file tells the linker the flash and RAM layout, so it won't clobber the bootloader or write to an out of bounds memory address. 
+You'll also need to copy the cargo config file from the [repo](https://github.com/rp-rs/rp-hal-boards/blob/main/.cargo/config.toml). It specifies the target and optimizing flags to the linker. You'll also need to copy [_memory.x_](https://github.com/rp-rs/rp-hal-boards/blob/main/memory.x) to your project root. This file tells the linker the flash and RAM layout, so it won't clobber the bootloader or write to an out of bounds memory address.
 
 The simplest working example, which does nothing except loop forever, is:
 

--- a/boards/sparkfun-micromod-rp2040/examples/sparkfun_micromod_battery_voltage.rs
+++ b/boards/sparkfun-micromod-rp2040/examples/sparkfun_micromod_battery_voltage.rs
@@ -3,7 +3,7 @@
 //! Continuously reads the battery voltage and prints it over defmt-rtt.
 //!
 //! Note that for this example to work, you need to change the runner
-//! to `probe-rs run` (in `.cargo/config` at the root of the repository)
+//! to `probe-rs run` (in `.cargo/config.toml` at the root of the repository)
 //! and connect to the RP2040 via SWD, preferredly via the Raspberry
 //! Pi Debug Probe.
 //!


### PR DESCRIPTION
The file was renamed to config.toml a while ago.

(This was fixed in #84 at one place, but we had some more locations with the same outdated reference.)