### PR TITLE
Add new BSP for Waveshare RP2040 Touch LCD 1.28 Inch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,33 @@
 [workspace]
 resolver = "2"
 members = [
-    "boards/adafruit-feather-rp2040",
-    "boards/adafruit-itsy-bitsy-rp2040",
-    "boards/adafruit-kb2040",
-    "boards/adafruit-macropad",
-    "boards/adafruit-metro-rp2040",
-    "boards/adafruit-qt-py-rp2040",
-    "boards/adafruit-trinkey-qt2040",
-    "boards/arduino_nano_connect",
-    "boards/boardsource-blok",
-    "boards/pimoroni_badger2040",
-    "boards/pimoroni-pico-explorer",
-    "boards/pimoroni-pico-lipo-16mb",
-    "boards/pimoroni-plasma-2040",
-    "boards/pimoroni-servo2040",
-    "boards/pimoroni-tiny2040",
-    "boards/pimoroni-tufty2040",
-    "boards/rp-pico",
-    "boards/seeeduino-xiao-rp2040",
-    "boards/solderparty-rp2040-stamp",
-    "boards/sparkfun-micromod-rp2040",
-    "boards/sparkfun-pro-micro-rp2040",
-    "boards/sparkfun-thing-plus-rp2040",
-    "boards/vcc-gnd-yd-rp2040",
-    "boards/waveshare-rp2040-zero",
-    "boards/waveshare-rp2040-lcd-0-96",
-	"boards/waveshare-rp2040-lcd-1-28",
+  "boards/adafruit-feather-rp2040",
+  "boards/adafruit-itsy-bitsy-rp2040",
+  "boards/adafruit-kb2040",
+  "boards/adafruit-macropad",
+  "boards/adafruit-metro-rp2040",
+  "boards/adafruit-qt-py-rp2040",
+  "boards/adafruit-trinkey-qt2040",
+  "boards/arduino_nano_connect",
+  "boards/boardsource-blok",
+  "boards/pimoroni_badger2040",
+  "boards/pimoroni-pico-explorer",
+  "boards/pimoroni-pico-lipo-16mb",
+  "boards/pimoroni-plasma-2040",
+  "boards/pimoroni-servo2040",
+  "boards/pimoroni-tiny2040",
+  "boards/pimoroni-tufty2040",
+  "boards/rp-pico",
+  "boards/seeeduino-xiao-rp2040",
+  "boards/solderparty-rp2040-stamp",
+  "boards/sparkfun-micromod-rp2040",
+  "boards/sparkfun-pro-micro-rp2040",
+  "boards/sparkfun-thing-plus-rp2040",
+  "boards/vcc-gnd-yd-rp2040",
+  "boards/waveshare-rp2040-zero",
+  "boards/waveshare-rp2040-lcd-0-96",
+  "boards/waveshare-rp2040-lcd-1-28",
+  "boards/waveshare-rp2040-touch-lcd-1-28",
 ]
 
 [workspace.dependencies]
@@ -43,13 +44,15 @@ embedded-graphics = "0.7.1"
 embedded-hal = "1.0.0"
 embedded-hal-nb = "1.0.0"
 embedded-sdmmc = "0.5.0"
-embedded_hal_0_2 = { package = "embedded-hal", version = "0.2.5", features = ["unproven", ] }
+embedded_hal_0_2 = { package = "embedded-hal", version = "0.2.5", features = [
+  "unproven",
+] }
 fugit = "0.3.7"
 hd44780-driver = "0.4.0"
 heapless = "0.7.16"
 i2c-pio = "0.8.0"
 nb = "1.1"
-panic-halt= "0.2.0"
+panic-halt = "0.2.0"
 panic-probe = "0.3.1"
 pio = "0.2.1"
 pio-proc = "0.2.2"

--- a/boards/waveshare-rp2040-touch-lcd-1-28/CHANGELOG.md
+++ b/boards/waveshare-rp2040-touch-lcd-1-28/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 0.1.0 - 2024-07-29
+
+### Changed
+
+- Inital release
+- Copied from waveshare-rp2040-0.96
+- Update board name
+

--- a/boards/waveshare-rp2040-touch-lcd-1-28/Cargo.toml
+++ b/boards/waveshare-rp2040-touch-lcd-1-28/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "waveshare-rp2040-touch-lcd-1-28"
+version = "0.8.0"
+authors = [
+  "René van Dorst <opensource@vdorst.com>",
+  "Andrea Nall <anall@andreanal.com>",
+  "TilCreator <contact.github@tc-j.de>",
+  "Anders Rasmussen <ando@mjolner.tech>",
+  "The rp-rs Developers",
+]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/waveshare-rp2040-touch-lcd-1-28"
+description = "Board Support Package for the Waveshare RP2040 Touch LCD 1.28 inch"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rp-rs/rp-hal-boards.git"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m-rt = { workspace = true, optional = true }
+rp2040-boot2 = { workspace = true, optional = true }
+rp2040-hal.workspace = true
+
+[dev-dependencies]
+cortex-m.workspace = true
+panic-halt.workspace = true
+embedded-hal.workspace = true
+fugit.workspace = true
+nb.workspace = true
+embedded-graphics.workspace = true
+gc9a01a_driver = { workspace = true }
+
+[features]
+# This is the set of features we enable by default
+default = ["boot2", "rt", "critical-section-impl", "rom-func-cache"]
+
+# critical section that is safe for multicore use
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
+
+# 2nd stage bootloaders for rp2040
+boot2 = ["rp2040-boot2"]
+
+# Minimal startup / runtime for Cortex-M microcontrollers
+rt = ["cortex-m-rt", "rp2040-hal/rt"]
+
+# This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
+# Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
+rp2040-e5 = ["rp2040-hal/rp2040-e5"]
+
+# Memoize(cache) ROM function pointers on first use to improve performance
+rom-func-cache = ["rp2040-hal/rom-func-cache"]
+
+# Disable automatic mapping of language features (like floating point math) to ROM functions
+disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
+
+# This enables ROM functions for f64 math that were not present in the earliest RP2040s
+rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]

--- a/boards/waveshare-rp2040-touch-lcd-1-28/README.md
+++ b/boards/waveshare-rp2040-touch-lcd-1-28/README.md
@@ -1,0 +1,97 @@
+# [waveshare-rp2040-lcd-1-28] - Board Support for the [Waveshare RP2040 LCD 1.28]
+
+You should include this crate if you are writing code that you want to run on
+an [Waveshare RP2040 LCD 1.28] - a very small RP2040 breakout board with USB-C, 
+a 65K IPS LCD 240x240, 16MBit Flash and 1A battery charger from Waveshare.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Feather.
+
+[Waveshare RP2040 LCD 1.28]: https://www.waveshare.com/wiki/RP2040-LCD-1.28
+[waveshare-rp2040-lcd-1-28]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/waveshare-rp2040-lcd-1-28
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+[Raspberry Silicon RP2040]: https://www.raspberrypi.org/products/rp2040/
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+waveshare_rp2040_lcd_1_28 = "0.8.0"
+```
+
+In your program, you will need to call `waveshare_rp2040_lcd_1_28::Pins::new` to create
+a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal-boards_ repository and run:
+
+```console
+rp-hal-boards/boards/waveshare-rp2040-lcd-1-28 $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal-boards/boards/waveshare-rp2040-lcd-1-28 $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs, then repeating the `cargo run` command above.
+```
+
+### [waveshare_rp2040_lcd_demo](./examples/waveshare_rp2040_lcd_demo.rs)
+
+Draws a red and green line with a blue regtangle.
+After that is fills the screen line for line, that end it starts over with an
+other colour, RED, GREEN and BLUE.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be, learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can choose either the MIT license or the
+Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific license.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/waveshare-rp2040-touch-lcd-1-28/examples/waveshare_rp2040_touch_lcd_demo.rs
+++ b/boards/waveshare-rp2040-touch-lcd-1-28/examples/waveshare_rp2040_touch_lcd_demo.rs
@@ -1,0 +1,163 @@
+//! Example of graphics on the LCD of the Waveshare RP2040-LCD-1.28
+//!
+//! Draws a red and green line with a blue rectangle.
+//! After that it fills the screen line for line, at the end it starts over with
+//! another colour, RED, GREEN and BLUE.
+#![no_std]
+#![no_main]
+
+use cortex_m::delay::Delay;
+use fugit::RateExtU32;
+use gc9a01a_driver::{Orientation, GC9A01A};
+use panic_halt as _;
+
+use waveshare_rp2040_touch_lcd_1_28::entry;
+use waveshare_rp2040_touch_lcd_1_28::{
+    hal::{
+        self,
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        pio::PIOExt,
+        watchdog::Watchdog,
+        Sio,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+
+use embedded_graphics::{
+    pixelcolor::Rgb565,
+    prelude::*,
+    primitives::{Line, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle},
+};
+
+const LCD_WIDTH: u32 = 240;
+const LCD_HEIGHT: u32 = 240;
+// Define static buffers
+
+/// Main entry point for the application
+#[entry]
+fn main() -> ! {
+    // Take ownership of peripheral instances
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Initialize watchdog
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    // Initialize clocks and PLLs
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // Initialize SIO
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // Set up the delay for the first core
+    let sys_freq = clocks.system_clock.freq().to_Hz();
+    let mut delay = Delay::new(core.SYST, sys_freq);
+
+    let (mut _pio, _sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+
+    // Initialize LCD pins
+    let lcd_dc = pins.lcd_dc.into_push_pull_output();
+    let lcd_cs = pins.lcd_cs.into_push_pull_output();
+    let lcd_clk = pins.lcd_clk.into_function::<hal::gpio::FunctionSpi>();
+    let lcd_mosi = pins.lcd_mosi.into_function::<hal::gpio::FunctionSpi>();
+    let lcd_rst = pins
+        .lcd_rst
+        .into_push_pull_output_in_state(hal::gpio::PinState::High);
+    let mut _lcd_bl = pins
+        .lcd_bl
+        .into_push_pull_output_in_state(hal::gpio::PinState::Low);
+
+    // Initialize SPI
+    let spi = hal::Spi::<_, _, _, 8>::new(pac.SPI1, (lcd_mosi, lcd_clk));
+    let spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        40.MHz(),
+        embedded_hal::spi::MODE_0,
+    );
+
+    // Initialize the display
+    let mut display = GC9A01A::new(spi, lcd_dc, lcd_cs, lcd_rst, false, LCD_WIDTH, LCD_HEIGHT);
+    display.init(&mut delay).unwrap();
+    display.set_orientation(&Orientation::Landscape).unwrap();
+
+    // Clear the screen before turning on the backlight
+    display.clear(Rgb565::BLACK).unwrap();
+    _lcd_bl.into_push_pull_output_in_state(hal::gpio::PinState::High);
+    delay.delay_ms(1000);
+
+    let lcd_zero = Point::zero();
+    let lcd_max_corner = Point::new((LCD_WIDTH - 1) as i32, (LCD_HEIGHT - 1) as i32);
+
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb565::BLUE)
+        .build();
+
+    Rectangle::with_corners(lcd_zero, lcd_max_corner)
+        .into_styled(style)
+        .draw(&mut display)
+        .unwrap();
+    delay.delay_ms(1000);
+
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb565::BLACK)
+        .build();
+
+    Rectangle::with_corners(
+        Point::new(1, 1),
+        Point::new((LCD_WIDTH - 2) as i32, (LCD_HEIGHT - 2) as i32),
+    )
+    .into_styled(style)
+    .draw(&mut display)
+    .unwrap();
+
+    Line::new(lcd_zero, lcd_max_corner)
+        .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
+        .draw(&mut display)
+        .unwrap();
+
+    Line::new(
+        Point::new(0, (LCD_HEIGHT - 1) as i32),
+        Point::new((LCD_WIDTH - 1) as i32, 0),
+    )
+    .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 1))
+    .draw(&mut display)
+    .unwrap();
+
+    // Infinite colour wheel loop
+    let mut l: i32 = 0;
+    let mut c = Rgb565::RED;
+    loop {
+        Line::new(Point::new(0, l), Point::new((LCD_WIDTH - 1) as i32, l))
+            .into_styled(PrimitiveStyle::with_stroke(c, 1))
+            .draw(&mut display)
+            .unwrap();
+        delay.delay_ms(10);
+        l += 1;
+        if l == LCD_HEIGHT as i32 {
+            l = 0;
+            c = match c {
+                Rgb565::RED => Rgb565::GREEN,
+                Rgb565::GREEN => Rgb565::BLUE,
+                _ => Rgb565::RED,
+            }
+        }
+    }
+}

--- a/boards/waveshare-rp2040-touch-lcd-1-28/src/lib.rs
+++ b/boards/waveshare-rp2040-touch-lcd-1-28/src/lib.rs
@@ -1,0 +1,785 @@
+#![no_std]
+
+pub extern crate rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use hal::entry;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+pub use hal::pac;
+
+hal::bsp_pins!(
+    /// GPIO 0 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp0Spi0Rx]          |
+    /// | `UART0 TX`   | [crate::Gp0Uart0Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp0I2C0Sda]         |
+    /// | `PWM0 A`     | [crate::Gp0Pwm0A]           |
+    /// | `PIO0`       | [crate::Gp0Pio0]            |
+    /// | `PIO1`       | [crate::Gp0Pio1]            |
+    Gpio0 {
+        name: gp0,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio0].
+            FunctionUart, PullNone: Gp0Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio0].
+            FunctionSpi, PullNone: Gp0Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio0].
+            FunctionI2C, PullUp: Gp0I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio0].
+            FunctionPwm, PullNone: Gp0Pwm0A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio0, PullNone: Gp0Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio1, PullNone: Gp0Pio1
+        }
+    },
+
+    /// GPIO 1 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp1Spi0Csn]         |
+    /// | `UART0 RX`   | [crate::Gp1Uart0Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp1I2C0Scl]         |
+    /// | `PWM0 B`     | [crate::Gp1Pwm0B]           |
+    /// | `PIO0`       | [crate::Gp1Pio0]            |
+    /// | `PIO1`       | [crate::Gp1Pio1]            |
+    Gpio1 {
+        name: gp1,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio1].
+            FunctionUart, PullNone: Gp1Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio1].
+            FunctionSpi, PullNone: Gp1Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio1].
+            FunctionI2C, PullUp: Gp1I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio1].
+            FunctionPwm, PullNone: Gp1Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio0, PullNone: Gp1Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio1, PullNone: Gp1Pio1
+        }
+    },
+
+    /// GPIO 2 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp2Spi0Sck]         |
+    /// | `UART0 CTS`  | [crate::Gp2Uart0Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp2I2C1Sda]         |
+    /// | `PWM1 A`     | [crate::Gp2Pwm1A]           |
+    /// | `PIO0`       | [crate::Gp2Pio0]            |
+    /// | `PIO1`       | [crate::Gp2Pio1]            |
+    Gpio2 {
+        name: gp2,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio2].
+            FunctionUart, PullNone: Gp2Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio2].
+            FunctionSpi, PullNone: Gp2Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio2].
+            FunctionI2C, PullUp: Gp2I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio2].
+            FunctionPwm, PullNone: Gp2Pwm1A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio2].
+            FunctionPio0, PullNone: Gp2Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio2].
+            FunctionPio1, PullNone: Gp2Pio1
+        }
+    },
+
+    /// GPIO 3 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp3Spi0Tx]          |
+    /// | `UART0 RTS`  | [crate::Gp3Uart0Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp3I2C1Scl]         |
+    /// | `PWM1 B`     | [crate::Gp3Pwm1B]           |
+    /// | `PIO0`       | [crate::Gp3Pio0]            |
+    /// | `PIO1`       | [crate::Gp3Pio1]            |
+    Gpio3 {
+        name: gp3,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio3].
+            FunctionUart, PullNone: Gp3Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio3].
+            FunctionSpi, PullNone: Gp3Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio3].
+            FunctionI2C, PullUp: Gp3I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio3].
+            FunctionPwm, PullNone: Gp3Pwm1B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio3].
+            FunctionPio0, PullNone: Gp3Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio3].
+            FunctionPio1, PullNone: Gp3Pio1
+        }
+    },
+
+    /// GPIO 4 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp4Spi0Rx]          |
+    /// | `UART1 TX`   | [crate::Gp4Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp4I2C0Sda]         |
+    /// | `PWM2 A`     | [crate::Gp4Pwm2A]           |
+    /// | `PIO0`       | [crate::Gp4Pio0]            |
+    /// | `PIO1`       | [crate::Gp4Pio1]            |
+    Gpio4 {
+        name: gp4,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio4].
+            FunctionUart, PullNone: Gp4Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio4].
+            FunctionSpi, PullNone: Gp4Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio4].
+            FunctionI2C, PullUp: Gp4I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio4].
+            FunctionPwm, PullNone: Gp4Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio0, PullNone: Gp4Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio1, PullNone: Gp4Pio1
+        }
+    },
+
+    /// GPIO 5 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp5Spi0Csn]         |
+    /// | `UART1 RX`   | [crate::Gp5Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp5I2C0Scl]         |
+    /// | `PWM2 B`     | [crate::Gp5Pwm2B]           |
+    /// | `PIO0`       | [crate::Gp5Pio0]            |
+    /// | `PIO1`       | [crate::Gp5Pio1]            |
+    Gpio5 {
+        name: gp5,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio5].
+            FunctionUart, PullNone: Gp5Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio5].
+            FunctionSpi, PullNone: Gp5Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio5].
+            FunctionI2C, PullUp: Gp5I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio5].
+            FunctionPwm, PullNone: Gp5Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio0, PullNone: Gp5Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio1, PullNone: Gp5Pio1
+        }
+    },
+
+    /// GPIO 6 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp6Spi0Sck]         |
+    /// | `UART1 CTS`  | [crate::Gp6Uart1Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp6I2C1Sda]         |
+    /// | `PWM3 A`     | [crate::Gp6Pwm3A]           |
+    /// | `PIO0`       | [crate::Gp6Pio0]            |
+    /// | `PIO1`       | [crate::Gp6Pio1]            |
+    Gpio6 {
+        name: i2c1_sda,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio6].
+            FunctionUart, PullNone: Gp6Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio6].
+            FunctionSpi, PullNone: Gp6Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio6].
+            FunctionI2C, PullUp: Gp6I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio6].
+            FunctionPwm, PullNone: Gp6Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio0, PullNone: Gp6Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio1, PullNone: Gp6Pio1
+        }
+    },
+
+    /// GPIO 7 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp7Spi0Tx]          |
+    /// | `UART1 RTS`  | [crate::Gp7Uart1Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp7I2C1Scl]         |
+    /// | `PWM3 B`     | [crate::Gp7Pwm3B]           |
+    /// | `PIO0`       | [crate::Gp7Pio0]            |
+    /// | `PIO1`       | [crate::Gp7Pio1]            |
+    Gpio7 {
+        name: i2c1_scl,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio7].
+            FunctionUart, PullNone: Gp7Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio7].
+            FunctionSpi, PullNone: Gp7Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio7].
+            FunctionI2C, PullUp: Gp7I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio7].
+            FunctionPwm, PullNone: Gp7Pwm3B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio0, PullNone: Gp7Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio1, PullNone: Gp7Pio1
+        }
+    },
+
+    /// GPIO 8 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp8Spi1Rx]          |
+    /// | `UART1 TX`   | [crate::Gp8Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp8I2C0Sda]         |
+    /// | `PWM4 A`     | [crate::Gp8Pwm4A]           |
+    /// | `PIO0`       | [crate::Gp8Pio0]            |
+    /// | `PIO1`       | [crate::Gp8Pio1]            |
+    Gpio8 {
+        name: lcd_dc,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio8].
+            FunctionUart, PullNone: Gp8Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio8].
+            FunctionSpi, PullNone: Gp8Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio8].
+            FunctionI2C, PullUp: Gp8I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio8].
+            FunctionPwm, PullNone: Gp8Pwm4A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio0, PullNone: Gp8Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio1, PullNone: Gp8Pio1
+        }
+    },
+
+    /// GPIO 9 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp9Spi1Csn]         |
+    /// | `UART1 RX`   | [crate::Gp9Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp9I2C0Scl]         |
+    /// | `PWM4 B`     | [crate::Gp9Pwm4B]           |
+    /// | `PIO0`       | [crate::Gp9Pio0]            |
+    /// | `PIO1`       | [crate::Gp9Pio1]            |
+    Gpio9 {
+        name: lcd_cs,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio9].
+            FunctionUart, PullNone: Gp9Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio9].
+            FunctionSpi, PullNone: Gp9Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio9].
+            FunctionI2C, PullUp: Gp9I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio9].
+            FunctionPwm, PullNone: Gp9Pwm4B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio0, PullNone: Gp9Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio1, PullNone: Gp9Pio1
+        }
+    },
+
+    /// GPIO 10 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp10Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp10Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp10I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp10Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp10Pio0]           |
+    /// | `PIO1`       | [crate::Gp10Pio1]           |
+    Gpio10 {
+        name: lcd_clk
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio10].
+            FunctionUart, PullNone: Gp10Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio10].
+            FunctionSpi, PullNone: Gp10Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio10].
+            FunctionI2C, PullUp: Gp10I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio10].
+            FunctionPwm, PullNone: Gp10Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio10].
+            FunctionPio0, PullNone: Gp10Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio10].
+            FunctionPio1, PullNone: Gp10Pio1
+        }
+    },
+
+    /// GPIO 11 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp11Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp11Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp11I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp11Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp11Pio0]           |
+    /// | `PIO1`       | [crate::Gp11Pio1]           |
+    Gpio11 {
+        name: lcd_mosi,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio11].
+            FunctionUart, PullNone: Gp11Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio11].
+            FunctionSpi, PullNone: Gp11Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio11].
+            FunctionI2C, PullUp: Gp11I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio11].
+            FunctionPwm, PullNone: Gp11Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio11].
+            FunctionPio0, PullNone: Gp11Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio11].
+            FunctionPio1, PullNone: Gp11Pio1
+        }
+    },
+
+    /// GPIO 12 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp12Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp12Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp12I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp12Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp12Pio0]           |
+    /// | `PIO1`       | [crate::Gp12Pio1]           |
+    Gpio12 {
+        name: lcd_miso,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio12].
+            FunctionUart, PullNone: Gp12Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio12].
+            FunctionSpi, PullNone: Gp12Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio12].
+            FunctionI2C, PullUp: Gp12I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio12].
+            FunctionPwm, PullNone: Gp12Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio12].
+            FunctionPio0, PullNone: Gp12Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio12].
+            FunctionPio1, PullNone: Gp12Pio1
+        }
+    },
+
+    /// GPIO 13 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp13Spi1Csn]        |
+    /// | `UART0 RX`   | [crate::Gp13Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp13I2C0Scl]        |
+    /// | `PWM6 B`     | [crate::Gp13Pwm6B]          |
+    /// | `PIO0`       | [crate::Gp13Pio0]           |
+    /// | `PIO1`       | [crate::Gp13Pio1]           |
+    Gpio13 {
+        name: lcd_rst,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio13].
+            FunctionUart, PullNone: Gp13Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio13].
+            FunctionSpi, PullNone: Gp13Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio13].
+            FunctionI2C, PullUp: Gp13I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio13].
+            FunctionPwm, PullNone: Gp13Pwm6B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio13].
+            FunctionPio0, PullNone: Gp13Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio13].
+            FunctionPio1, PullNone: Gp13Pio1
+        }
+    },
+
+    /// GPIO 14 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp14Spi1Sck]        |
+    /// | `UART0 CTS`  | [crate::Gp14Uart0Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp14I2C1Sda]        |
+    /// | `PWM7 A`     | [crate::Gp14Pwm7A]          |
+    /// | `PIO0`       | [crate::Gp14Pio0]           |
+    /// | `PIO1`       | [crate::Gp14Pio1]           |
+    Gpio14 {
+        name: gp14,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio14].
+            FunctionUart, PullNone: Gp14Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio14].
+            FunctionSpi, PullNone: Gp14Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio14].
+            FunctionI2C, PullUp: Gp14I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio14].
+            FunctionPwm, PullNone: Gp14Pwm7A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio14].
+            FunctionPio0, PullNone: Gp14Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio14].
+            FunctionPio1, PullNone: Gp14Pio1
+        }
+    },
+
+    /// GPIO 15 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp15Spi1Tx]         |
+    /// | `UART0 RTS`  | [crate::Gp15Uart0Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp15I2C1Scl]        |
+    /// | `PWM7 B`     | [crate::Gp15Pwm7B]          |
+    /// | `PIO0`       | [crate::Gp15Pio0]           |
+    /// | `PIO1`       | [crate::Gp15Pio1]           |
+    Gpio15 {
+        name: gp15,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio15].
+            FunctionUart, PullNone: Gp15Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio15].
+            FunctionSpi, PullNone: Gp15Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio15].
+            FunctionI2C, PullUp: Gp15I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio15].
+            FunctionPwm, PullNone: Gp15Pwm7B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio15].
+            FunctionPio0, PullNone: Gp15Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio15].
+            FunctionPio1, PullNone: Gp15Pio1
+        }
+    },
+
+    /// GPIO 16 is connected internally to a single Neopixel RGB LED
+    Gpio16 { name: neopixel },
+
+    /// GPIO 17 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp17Spi0Csn]        |
+    /// | `UART0 RX`   | [crate::Gp17Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp17I2C0Scl]        |
+    /// | `PWM0 B`     | [crate::Gp17Pwm0B]          |
+    /// | `PIO0`       | [crate::Gp17Pio0]           |
+    /// | `PIO1`       | [crate::Gp17Pio1]           |
+    Gpio17 {
+        name: gpio17,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio17].
+            FunctionUart, PullNone: Gp17Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio17].
+            FunctionSpi, PullNone: Gp17Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio17].
+            FunctionI2C, PullUp: Gp17I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio17].
+            FunctionPwm, PullNone: Gp17Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio0, PullNone: Gp17Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio1, PullNone: Gp17Pio1
+        }
+    },
+
+    /// GPIO 18 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp18Spi0Sck]        |
+    /// | `UART0 CTS`  | [crate::Gp18Uart0Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp18I2C1Sda]        |
+    /// | `PWM1 A`     | [crate::Gp18Pwm1A]          |
+    /// | `PIO0`       | [crate::Gp18Pio0]           |
+    /// | `PIO1`       | [crate::Gp18Pio1]           |
+    Gpio18 {
+        name: gpio18,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio18].
+            FunctionUart, PullNone: Gp18Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio18].
+            FunctionSpi, PullNone: Gp18Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio18].
+            FunctionI2C, PullUp: Gp18I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio18].
+            FunctionPwm, PullNone: Gp18Pwm1A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio18].
+            FunctionPio0, PullNone: Gp18Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio18].
+            FunctionPio1, PullNone: Gp18Pio1
+        }
+    },
+
+    /// GPIO 19 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp19Spi0Tx]         |
+    /// | `UART0 RTS`  | [crate::Gp19Uart0Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp19I2C1Scl]        |
+    /// | `PWM1 B`     | [crate::Gp19Pwm1B]          |
+    /// | `PIO0`       | [crate::Gp19Pio0]           |
+    /// | `PIO1`       | [crate::Gp19Pio1]           |
+    Gpio19 {
+        name: gpio19,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio19].
+            FunctionUart, PullNone: Gp19Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio19].
+            FunctionSpi, PullNone: Gp19Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio19].
+            FunctionI2C, PullUp: Gp19I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio19].
+            FunctionPwm, PullNone: Gp19Pwm1B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio19].
+            FunctionPio0, PullNone: Gp19Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio19].
+            FunctionPio1, PullNone: Gp19Pio1
+        }
+    },
+
+    /// GPIO 20 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp20Spi0Rx]         |
+    /// | `UART1 TX`   | [crate::Gp20Uart1Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp20I2C0Sda]        |
+    /// | `PWM2 A`     | [crate::Gp20Pwm2A]          |
+    /// | `PIO0`       | [crate::Gp20Pio0]           |
+    /// | `PIO1`       | [crate::Gp20Pio1]           |
+    Gpio20 {
+        name: gpio20,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio20].
+            FunctionUart, PullNone: Gp20Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio20].
+            FunctionSpi, PullNone: Gp20Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio20].
+            FunctionI2C, PullUp: Gp20I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio20].
+            FunctionPwm, PullNone: Gp20Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio0, PullNone: Gp20Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio1, PullNone: Gp20Pio1
+        }
+    },
+
+    /// GPIO 21 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp21Spi0Csn]        |
+    /// | `UART1 RX`   | [crate::Gp21Uart1Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp21I2C0Scl]        |
+    /// | `PWM2 B`     | [crate::Gp21Pwm2B]          |
+    /// | `PIO0`       | [crate::Gp21Pio0]           |
+    /// | `PIO1`       | [crate::Gp21Pio1]           |
+    Gpio21 {
+        name: tp_int,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio21].
+            FunctionUart, PullNone: Gp21Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio21].
+            FunctionSpi, PullNone: Gp21Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio21].
+            FunctionI2C, PullUp: Gp21I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio21].
+            FunctionPwm, PullNone: Gp21Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio0, PullNone: Gp21Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio1, PullNone: Gp21Pio1
+        }
+    },
+
+    /// GPIO 22 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp22Spi0Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp22Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp22I2C1Sda]        |
+    /// | `PWM3 A`     | [crate::Gp22Pwm3A]          |
+    /// | `PIO0`       | [crate::Gp22Pio0]           |
+    /// | `PIO1`       | [crate::Gp22Pio1]           |
+    Gpio22 {
+        name: tp_rst,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio22].
+            FunctionUart, PullNone: Gp22Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio22].
+            FunctionSpi, PullNone: Gp22Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio22].
+            FunctionI2C, PullUp: Gp22I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio22].
+            FunctionPwm, PullNone: Gp22Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio0, PullNone: Gp22Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio1, PullNone: Gp22Pio1
+        }
+    },
+
+    /// GPIO 23
+    Gpio23 {
+        name: imu_int1,
+        aliases: {
+            FunctionUart, PullNone: Gp23Uart1Rts,
+            FunctionSpi, PullNone: Gp23Spi0Tx,
+            FunctionI2C, PullUp: Gp23I2C1Scl,
+            FunctionPwm, PullNone: Gp23Pwm3B,
+            FunctionPio0, PullNone: Gp23Pio0,
+            FunctionPio1, PullNone: Gp23Pio1
+        }
+    },
+
+    /// GPIO 24
+    Gpio24 {
+        name: imu_int2,
+        aliases: {
+            FunctionUart, PullNone: Gp24Uart1Tx,
+            FunctionSpi, PullNone: Gp24Spi1Rx,
+            FunctionI2C, PullUp: Gp24I2C0Sda,
+            FunctionPwm, PullNone: Gp24Pwm4A,
+            FunctionPio0, PullNone: Gp24Pio0,
+            FunctionPio1, PullNone: Gp24Pio1
+        }
+    },
+
+    /// GPIO 25
+    Gpio25 {
+        name: lcd_bl,
+        aliases: {
+            FunctionUart, PullNone: Gp25Uart1Rx,
+            FunctionSpi, PullNone: Gp25Spi1Csn,
+            FunctionI2C, PullUp: Gp25I2C0Scl,
+            FunctionPwm, PullNone: Gp25Pwm4B,
+            FunctionPio0, PullNone: Gp25Pio0,
+            FunctionPio1, PullNone: Gp25Pio1
+        }
+    },
+
+    /// GPIO 26 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp26Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp26Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp26I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp26Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp26Pio0]           |
+    /// | `PIO1`       | [crate::Gp26Pio1]           |
+    ///
+    /// ADC0
+    Gpio26 {
+        name: gp26,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio26].
+            FunctionUart, PullNone: Gp26Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio26].
+            FunctionSpi, PullNone: Gp26Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio26].
+            FunctionI2C, PullUp: Gp26I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio26].
+            FunctionPwm, PullNone: Gp26Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio0, PullNone: Gp26Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio1, PullNone: Gp26Pio1
+        }
+    },
+
+    /// GPIO 27 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp27Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp27Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp27I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp27Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp27Pio0]           |
+    /// | `PIO1`       | [crate::Gp27Pio1]           |
+    ///
+    /// ADC1
+    Gpio27 {
+        name: gp27,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio27].
+            FunctionUart, PullNone: Gp27Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio27].
+            FunctionSpi, PullNone: Gp27Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio27].
+            FunctionI2C, PullUp: Gp27I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio27].
+            FunctionPwm, PullNone: Gp27Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio0, PullNone: Gp27Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio1, PullNone: Gp27Pio1
+        }
+    },
+
+    /// GPIO 28 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp28Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp28Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp28I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp28Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp28Pio0]           |
+    /// | `PIO1`       | [crate::Gp28Pio1]           |
+    ///
+    /// ADC2
+    Gpio28 {
+        name: gp28,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio28].
+            FunctionUart, PullNone: Gp28Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio28].
+            FunctionSpi, PullNone: Gp28Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio28].
+            FunctionI2C, PullUp: Gp28I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio28].
+            FunctionPwm, PullNone: Gp28Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio0, PullNone: Gp28Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio1, PullNone: Gp28Pio1
+        }
+    },
+
+    /// GPIO 29
+    ///
+    /// ADC3
+    Gpio29 {
+        name: bat_adc,
+        aliases: {
+            FunctionUart, PullNone: Gp29Uart0Rx,
+            FunctionSpi, PullNone: Gp29Spi1Csn,
+            FunctionI2C, PullUp: Gp29I2C0Scl,
+            FunctionPwm, PullNone: Gp29Pwm6B,
+            FunctionPio0, PullNone: Gp29Pio0,
+            FunctionPio1, PullNone: Gp29Pio1
+        }
+    },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
This BSP is made from a copy of the LCD 1.28 Inch BSP in this repo and modified to support the Touch version, which is very slightly different.

I'm very new to creating a BSP, so any feedback is welcome. Especially around making sure that the pins are correctly specified.

The Schematic was very helpful in making sure I named the LCD and Touch pins correctly.

[Waveshare RP2040 Touch LCD 1.28inch wiki](https://www.waveshare.com/wiki/RP2040-Touch-LCD-1.28)