### PR TITLE
CI fixes

### DIFF
--- a/boards/boardsource-blok/examples/blok_usb_keyboard_input.rs
+++ b/boards/boardsource-blok/examples/blok_usb_keyboard_input.rs
@@ -13,6 +13,7 @@
 
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 
 use boardsource_blok::{entry, hal};
 use boardsource_blok::{

--- a/boards/rp-pico/examples/pico_uart_irq_buffer.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_buffer.rs
@@ -16,6 +16,7 @@
 
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 
 // These are the traits we need from Embedded HAL to treat our hardware
 // objects as generic embedded devices.

--- a/boards/rp-pico/examples/pico_uart_irq_echo.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_echo.rs
@@ -14,6 +14,7 @@
 
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 
 // These are the traits we need from Embedded HAL to treat our hardware
 // objects as generic embedded devices.

--- a/boards/rp-pico/examples/pico_usb_serial_interrupt.rs
+++ b/boards/rp-pico/examples/pico_usb_serial_interrupt.rs
@@ -11,6 +11,7 @@
 
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 
 // The macro for our start-up function
 use rp_pico::entry;

--- a/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
+++ b/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
@@ -13,6 +13,7 @@
 
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 
 // The macro for our start-up function
 use rp_pico::entry;

--- a/boards/rp-pico/src/lib.rs
+++ b/boards/rp-pico/src/lib.rs
@@ -54,7 +54,6 @@ extern crate cortex_m_rt;
 ///   loop {}
 /// }
 /// ```
-
 #[cfg(feature = "rt")]
 pub use hal::entry;
 

--- a/boards/sparkfun-micromod-rp2040/src/lib.rs
+++ b/boards/sparkfun-micromod-rp2040/src/lib.rs
@@ -54,7 +54,6 @@ extern crate cortex_m_rt;
 ///   loop {}
 /// }
 /// ```
-
 #[cfg(feature = "rt")]
 pub use hal::entry;
 


### PR DESCRIPTION
This fixes the code that was causing clippy lint [empty_line_after_doc_comments](https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments).
I've also suppressed the lint for [static_mut_refs](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#static-mut-refs) in the examples that use static mut.