### PR TITLE
Add BSP for Adafruit Feather RP2040 Adalogger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "boards/adafruit-feather-rp2040",
+    "boards/adafruit-feather-rp2040-adalogger",
     "boards/adafruit-itsy-bitsy-rp2040",
     "boards/adafruit-kb2040",
     "boards/adafruit-macropad",
@@ -56,7 +57,7 @@ panic-probe = "0.3.1"
 pio = "0.2.1"
 pio-proc = "0.2.2"
 rp2040-boot2 = "0.3.0"
-rp2040-hal = "0.10.0"
+rp2040-hal = "0.11.0"
 st7789 = "0.6.1"
 st7735-lcd = "0.8.1"
 smart-leds = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ RP2040 chip according to how it is connected up on the Feather RP2040.
 [Adafruit Feather RP2040]: https://www.adafruit.com/product/4884
 [adafruit-feather-rp2040]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-feather-rp2040
 
+### [adafruit-feather-rp2040-adalogger] - Board Support for the [Adafruit Feather RP2040 Adalogger]
+
+You should include this crate if you are writing code that you want to run on
+an [Adafruit Feather RP2040 Adalogger] - a Feather form-factor RP2040 board from Adafruit.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Feather Adalogger.
+
+[Adafruit Feather RP2040 Adalogger]: https://www.adafruit.com/product/5980
+[adafruit-feather-rp2040-adalogger]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-feather-rp2040-adalogger
+
+
 ### [adafruit-itsy-bitsy-rp2040] - Board Support for the [Adafruit ItsyBitsy RP2040]
 
 You should include this crate if you are writing code that you want to run on

--- a/boards/adafruit-feather-rp2040-adalogger/CHANGELOG.md
+++ b/boards/adafruit-feather-rp2040-adalogger/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 0.1.0 - 2021-12-20
+
+- Initial release
+- Copied from `adafruit-feather-rp2040`
+

--- a/boards/adafruit-feather-rp2040-adalogger/Cargo.toml
+++ b/boards/adafruit-feather-rp2040-adalogger/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "adafruit-feather-rp2040-adalogger"
+version = "0.8.0"
+authors = ["The rp-rs Developers"]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-feather-rp2040"
+description = "Board Support Package for the Adafruit Feather RP2040 Adalogger"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rp-rs/rp-hal-boards.git"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m-rt = { workspace = true, optional = true }
+rp2040-boot2 = { workspace = true, optional = true }
+rp2040-hal.workspace = true
+
+[dev-dependencies]
+cortex-m.workspace = true
+panic-halt.workspace = true
+embedded-hal.workspace = true
+smart-leds.workspace = true
+ws2812-pio.workspace = true
+
+[features]
+# This is the set of features we enable by default
+default = ["boot2", "rt", "critical-section-impl", "rom-func-cache", "rom-v2-intrinsics"]
+
+# critical section that is safe for multicore use
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
+
+# 2nd stage bootloaders for rp2040
+boot2 = ["rp2040-boot2"]
+
+# Minimal startup / runtime for Cortex-M microcontrollers
+rt = ["cortex-m-rt","rp2040-hal/rt"]
+
+# This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
+# All RP2040 Adalogger boards so far have been B1, so this errata always applies
+# Source: https://github.com/b4shful/pico-sdk/blob/e674cbe1cfb76e0e6ed82f5a3ddca28446dcd31c/src/boards/include/boards/adafruit_feather_rp2040_adalogger.h#L115
+rp2040-e5 = ["rp2040-hal/rp2040-e5"]
+
+# Memoize(cache) ROM function pointers on first use to improve performance
+rom-func-cache = ["rp2040-hal/rom-func-cache"]
+
+# Disable automatic mapping of language features (like floating point math) to ROM functions
+disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
+
+# This enables ROM functions for f64 math that were not present in the earliest RP2040s
+# Since all Adaloggers are B1, this is always supported
+rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]

--- a/boards/adafruit-feather-rp2040-adalogger/README.md
+++ b/boards/adafruit-feather-rp2040-adalogger/README.md
@@ -1,0 +1,98 @@
+# [adafruit-feather-rp2040-adalogger] - Board Support for the [Adafruit Feather RP2040 Adalogger]
+
+You should include this crate if you are writing code that you want to run on
+an [Adafruit Feather RP2040 Adalogger] - a Feather form-factor RP2040 board from Adafruit.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Feather Adalogger.
+
+[Adafruit Feather RP2040 Adalogger]: https://www.adafruit.com/product/5980
+[adafruit-feather-rp2040-adalogger]: https://github.com/rp-rs/rp-hal-boards/tree/main/boards/adafruit-feather-rp2040-adalogger
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+[Raspberry Silicon RP2040]: https://www.raspberrypi.org/products/rp2040/
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+adafruit-feather-rp2040-adalogger = "0.8.0"
+```
+
+In your program, you will need to call `adafruit_feather_rp2040_adalogger::Pins::new`
+to create  a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal-boards_ repository and run:
+
+```console
+rp-hal-boards/boards/adafruit-feather-rp2040-adalogger $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal-boards_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal-boards/boards/adafruit-feather-rp2040-adalogger $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs, then repeating the `cargo run` command above.
+```
+
+### [adafruit_feather_adalogger_blinky](examples/adafruit_feather_adalogger_blinky.rs)
+
+Flashes the Feather's onboard LED on and off.
+
+### [adafruit_feather_adalogger_neopixel_rainbow](examples/adafruit_feather_adalogger_neopixel_rainbow.rs)
+
+Flows smoothly through various colors on the Feather's onboard NeoPixel LED.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be, learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal-boards/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can choose either the MIT license or the
+Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific license.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/adafruit-feather-rp2040-adalogger/examples/adafruit_feather_adalogger_blinky.rs
+++ b/boards/adafruit-feather-rp2040-adalogger/examples/adafruit_feather_adalogger_blinky.rs
@@ -1,0 +1,57 @@
+//! Blinks the LED on a Adafruit Feather RP2040 Adalogger board
+//!
+//! This will blink on-board LED.
+#![no_std]
+#![no_main]
+
+use adafruit_feather_rp2040_adalogger::entry;
+use adafruit_feather_rp2040_adalogger::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        watchdog::Watchdog,
+        Sio,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+use embedded_hal::digital::OutputPin;
+use panic_halt as _;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+    // Pin 13 both powers the onboard red LED and serves as a normal digital IO pin 
+    let mut led_pin = pins.d13.into_push_pull_output();
+
+    loop {
+        led_pin.set_high().unwrap();
+        delay.delay_ms(1500);
+        led_pin.set_low().unwrap();
+        delay.delay_ms(1500);
+    }
+}

--- a/boards/adafruit-feather-rp2040-adalogger/examples/adafruit_feather_adalogger_neopixel_rainbow.rs
+++ b/boards/adafruit-feather-rp2040-adalogger/examples/adafruit_feather_adalogger_neopixel_rainbow.rs
@@ -1,0 +1,95 @@
+//! Rainbow effect color wheel using the onboard NeoPixel on an Adafruit Feather RP2040 Adalogger
+//! board
+//!
+//! This flows smoothly through various colors on the onboard NeoPixel.
+//! Uses the `ws2812_pio` driver to control the NeoPixel, which in turns uses the
+//! RP2040's PIO block.
+#![no_std]
+#![no_main]
+
+use adafruit_feather_rp2040_adalogger::entry;
+use adafruit_feather_rp2040_adalogger::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        pio::PIOExt,
+        timer::Timer,
+        watchdog::Watchdog,
+        Sio,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+use core::iter::once;
+use embedded_hal::delay::DelayNs;
+use panic_halt as _;
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+use ws2812_pio::Ws2812;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let timer = Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
+
+    // Configure the addressable LED
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+    let mut ws = Ws2812::new(
+        // The onboard NeoPixel is attached to GPIO pin #17 on the Feather RP2040 Adalogger.
+        pins.neopixel.into_function(),
+        &mut pio,
+        sm0,
+        clocks.peripheral_clock.freq(),
+        timer.count_down(),
+    );
+
+    // Infinite colour wheel loop
+    let mut n: u8 = 128;
+    let mut timer = timer; // rebind to force a copy of the timer
+    loop {
+        ws.write(brightness(once(wheel(n)), 32)).unwrap();
+        n = n.wrapping_add(1);
+
+        timer.delay_ms(25);
+    }
+}
+
+/// Convert a number from `0..=255` to an RGB color triplet.
+///
+/// The colours are a transition from red, to green, to blue and back to red.
+fn wheel(mut wheel_pos: u8) -> RGB8 {
+    wheel_pos = 255 - wheel_pos;
+    if wheel_pos < 85 {
+        // No green in this sector - red and blue only
+        (255 - (wheel_pos * 3), 0, wheel_pos * 3).into()
+    } else if wheel_pos < 170 {
+        // No red in this sector - green and blue only
+        wheel_pos -= 85;
+        (0, wheel_pos * 3, 255 - (wheel_pos * 3)).into()
+    } else {
+        // No blue in this sector - red and green only
+        wheel_pos -= 170;
+        (wheel_pos * 3, 255 - (wheel_pos * 3), 0).into()
+    }
+}

--- a/boards/adafruit-feather-rp2040-adalogger/src/lib.rs
+++ b/boards/adafruit-feather-rp2040-adalogger/src/lib.rs
@@ -1,0 +1,120 @@
+#![no_std]
+
+pub extern crate rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use hal::entry;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+// The actual flash used is the W25Q64JVXGIQ, but this firmware is compatible
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
+
+pub use hal::pac;
+
+hal::bsp_pins!(
+    Gpio0 {
+        name: tx,
+        aliases: { FunctionUart, PullNone: UartTx }
+    },
+    Gpio1 {
+        name: rx,
+        aliases: { FunctionUart, PullNone: UartRx }
+    },
+    Gpio2 {
+        name: sda,
+        aliases: { FunctionI2C, PullUp: Sda }
+    },
+    Gpio3 {
+        name: scl,
+        aliases: { FunctionI2C, PullUp: Scl }
+    },
+    Gpio4 { name: d4 },
+    Gpio5 { name: d5 },
+    Gpio6 { name: d6 },
+    Gpio7 { name: button },
+    Gpio8 {
+        name: miso,
+        aliases: { FunctionSpi, PullNone: Miso }
+    },
+    Gpio9 { name: d9 },
+    Gpio10 { name: d10 },
+    Gpio11 { name: d11 },
+    Gpio12 { name: d12 },
+    Gpio13 { name: d13 },
+    Gpio14 {
+        name: sck,
+        aliases: { FunctionSpi, PullNone: Sclk }
+    },
+    Gpio15 {
+        name: mosi,
+        aliases: { FunctionSpi, PullNone: Mosi }
+    },
+    Gpio16 {
+        name: sd_card_detect,
+        aliases: {
+            FunctionNull, PullNone: SdioCd
+        }
+    },
+    Gpio17 { name: neopixel },
+    Gpio18 {
+        name: sd_clk,
+        aliases: {
+            FunctionSpi, PullNone: SdClk,
+            FunctionPio0, PullNone: SdioSckPio0,
+            FunctionPio1, PullNone: SdioSckPio1
+        }
+    },
+    Gpio19 {
+        name: sd_mosi,
+        aliases: {
+            FunctionSpi, PullNone: SdMosi,
+            FunctionPio0, PullNone: SdioCmdPio0,
+            FunctionPio1, PullNone: SdioCmdPio1
+        }
+    },
+    Gpio20 {
+        name: sd_miso,
+        aliases: {
+            FunctionSpi, PullNone: SdMiso,
+            FunctionPio0, PullNone: SdioData0Pio0,
+            FunctionPio1, PullNone: SdioData0Pio1
+        }
+    },
+    Gpio21 {
+        name: sd_dat1,
+        aliases: {
+            FunctionPio0, PullNone: SdioData1Pio0,
+            FunctionPio1, PullNone: SdioData1Pio1
+        }
+    },
+    Gpio22 {
+        name: sd_dat2,
+        aliases: {
+            FunctionPio0, PullNone: SdioData2Pio0,
+            FunctionPio1, PullNone: SdioData2Pio1
+        }
+    },
+    Gpio23 {
+        name: sd_cs,
+        aliases: {
+            FunctionSpi, PullNone: SdCs,
+            FunctionPio0, PullNone: SdioData3Pio0,
+            FunctionPio1, PullNone: SdioData3Pio1
+        }
+    },
+    Gpio24 { name: d24 },
+    Gpio25 { name: d25 },
+    Gpio26 { name: a0 },
+    Gpio27 { name: a1 },
+    Gpio28 { name: a2 },
+    Gpio29 { name: a3 },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
Largely copied from the BSP for the base model Feather RP2040. I removed the authors of that BSP from `Cargo.toml`, but I'm not sure if this was the right choice - let me know if not.