### PR TITLE
Migrate pimoroni-pico-explorer to mipidsi driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
     "boards/vcc-gnd-yd-rp2040",
     "boards/waveshare-rp2040-zero",
     "boards/waveshare-rp2040-lcd-0-96",
-	"boards/waveshare-rp2040-lcd-1-28",
+    "boards/waveshare-rp2040-lcd-1-28",
 ]
 
 [workspace.dependencies]
@@ -42,7 +42,9 @@ defmt-rtt = "0.4.0"
 display-interface = "0.4.1"
 display-interface-spi = "0.4.1"
 embedded-graphics = "0.7.1"
+embedded-graphics_0_8 = { package = "embedded-graphics", version = "0.8.1" }
 embedded-hal = "1.0.0"
+embedded-hal-bus = "0.3.0"
 embedded-hal-nb = "1.0.0"
 embedded-sdmmc = "0.5.0"
 embedded_hal_0_2 = { package = "embedded-hal", version = "0.2.5", features = ["unproven", ] }
@@ -50,17 +52,20 @@ fugit = "0.3.7"
 hd44780-driver = "0.4.0"
 heapless = "0.7.16"
 i2c-pio = "0.8.0"
+mipidsi = "0.9.0"
 nb = "1.1"
 panic-halt= "0.2.0"
 panic-probe = "0.3.1"
 pio = "0.2.1"
 pio-proc = "0.2.2"
+portable-atomic = { version = "1.13.0", features = [ "critical-section" ] }
 rp2040-boot2 = "0.3.0"
 rp2040-hal = "0.10.0"
 st7789 = "0.6.1"
 st7735-lcd = "0.8.1"
 smart-leds = "0.3.0"
 ssd1306 = "0.7.1"
+static_cell = "2.1.1"
 usb-device = "0.3.1"
 usbd-hid = "0.7.0"
 usbd-serial = "0.2.1"

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -11,23 +11,22 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m.workspace = true
 cortex-m-rt = { workspace = true, optional = true }
+cortex-m.workspace = true
 display-interface-spi.workspace = true
-embedded-graphics = "0.8.1"
-embedded-hal = { workspace = true }
-embedded-hal-bus = "0.3.0"
 embedded_hal_0_2.workspace = true
+embedded-graphics_0_8.workspace = true
+embedded-hal-bus.workspace = true
+embedded-hal.workspace = true
 fugit.workspace = true
-mipidsi = "0.9.0"
-portable-atomic = { version = "1.13.0", features = ["critical-section"] }
+mipidsi.workspace = true
+portable-atomic.workspace = true
 rp2040-boot2 = { workspace = true, optional = true }
 rp2040-hal.workspace = true
-static_cell = "2.1.1"
+static_cell.workspace = true
 
 [dev-dependencies]
 arrayvec.workspace = true
-cortex-m.workspace = true
 display-interface.workspace = true
 nb.workspace = true
 panic-halt.workspace = true

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -11,15 +11,19 @@ repository = "https://github.com/rp-rs/rp-hal-boards.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cortex-m.workspace = true
 cortex-m-rt = { workspace = true, optional = true }
 display-interface-spi.workspace = true
-embedded-graphics.workspace = true
+embedded-graphics = "0.8.1"
 embedded-hal = { workspace = true }
+embedded-hal-bus = "0.3.0"
 embedded_hal_0_2.workspace = true
 fugit.workspace = true
+mipidsi = "0.9.0"
+portable-atomic = { version = "1.13.0", features = ["critical-section"] }
 rp2040-boot2 = { workspace = true, optional = true }
 rp2040-hal.workspace = true
-st7789.workspace = true
+static_cell = "2.1.1"
 
 [dev-dependencies]
 arrayvec.workspace = true

--- a/boards/pimoroni-pico-explorer/examples/pimoroni_pico_explorer_showcase.rs
+++ b/boards/pimoroni-pico-explorer/examples/pimoroni_pico_explorer_showcase.rs
@@ -3,7 +3,7 @@
 
 use arrayvec::ArrayString;
 use core::fmt::Write;
-use embedded_graphics::{
+use embedded_graphics_0_8::{
     mono_font::{ascii::FONT_10X20, MonoTextStyleBuilder},
     pixelcolor::Rgb565,
     prelude::*,

--- a/boards/pimoroni-pico-explorer/src/lib.rs
+++ b/boards/pimoroni-pico-explorer/src/lib.rs
@@ -20,12 +20,11 @@ pub use hal::entry;
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
 use cortex_m::delay::Delay;
-use embedded_graphics::{draw_target::DrawTarget, pixelcolor::Rgb565, prelude::RgbColor};
-use embedded_hal::delay::DelayNs;
+use embedded_graphics_0_8::{draw_target::DrawTarget, pixelcolor::Rgb565, prelude::RgbColor};
+use embedded_hal::{delay::DelayNs, spi::MODE_0};
 use embedded_hal_0_2::{
     adc::{Channel, OneShot},
     digital::v2::InputPin,
-    spi::MODE_0,
 };
 use embedded_hal_bus::spi::{ExclusiveDevice, NoDelay};
 use fugit::RateExtU32;

--- a/boards/pimoroni-pico-explorer/src/lib.rs
+++ b/boards/pimoroni-pico-explorer/src/lib.rs
@@ -19,33 +19,29 @@ pub use hal::entry;
 #[used]
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
-use display_interface_spi::SPIInterface;
-use embedded_graphics::{
-    draw_target::DrawTarget,
-    pixelcolor::{Rgb565, RgbColor},
-};
+use cortex_m::delay::Delay;
+use embedded_graphics::{draw_target::DrawTarget, pixelcolor::Rgb565, prelude::RgbColor};
+use embedded_hal::delay::DelayNs;
 use embedded_hal_0_2::{
     adc::{Channel, OneShot},
-    blocking::delay::DelayUs,
-    digital::v2::{InputPin, OutputPin},
+    digital::v2::InputPin,
     spi::MODE_0,
 };
+use embedded_hal_bus::spi::{ExclusiveDevice, NoDelay};
 use fugit::RateExtU32;
 pub use hal::pac;
 use hal::{
     adc::Adc,
     gpio::{
-        bank0::{
-            Gpio0, Gpio1, Gpio12, Gpio13, Gpio14, Gpio15, Gpio16, Gpio17, Gpio2, Gpio22, Gpio23,
-            Gpio24, Gpio25, Gpio26, Gpio27, Gpio28, Gpio29, Gpio3, Gpio4, Gpio5, Gpio6, Gpio7,
-        },
-        FunctionNull, FunctionPwm, FunctionSioInput, FunctionSioOutput, Pin, PullNone, PullUp,
+        bank0::*, FunctionNull, FunctionPwm, FunctionSio, FunctionSioInput, FunctionSpi, Pin,
+        PullNone, PullUp, SioOutput,
     },
     pac::{RESETS, SPI0},
     sio::SioGpioBank0,
     spi::{Enabled, Spi},
 };
-use st7789::ST7789;
+use mipidsi::{interface::SpiInterface, models::ST7789, Builder, Display, NoResetPin};
+use static_cell::StaticCell;
 
 pub mod all_pins {
     hal::bsp_pins!(
@@ -137,6 +133,7 @@ pub struct Pins {
 }
 
 pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;
+
 pub enum Button {
     A,
     B,
@@ -155,37 +152,64 @@ pub enum MotorAction {
     Stop,
 }
 
-pub type Screen = ST7789<
-    SPIInterface<
-        Spi<Enabled, SPI0, (all_pins::Mosi, all_pins::Sclk), 8>,
-        Pin<Gpio16, FunctionSioOutput, PullNone>,
-        Pin<Gpio17, FunctionSioOutput, PullNone>,
+pub type Screen<'a> = Display<
+    SpiInterface<
+        'a,
+        ExclusiveDevice<
+            Spi<
+                Enabled,
+                SPI0,
+                (
+                    Pin<Gpio19, FunctionSpi, PullNone>,
+                    Pin<Gpio18, FunctionSpi, PullNone>,
+                ),
+            >,
+            Pin<Gpio17, FunctionSio<SioOutput>, PullNone>,
+            NoDelay,
+        >,
+        Pin<Gpio16, FunctionSio<SioOutput>, PullNone>,
     >,
-    DummyPin,
+    ST7789,
+    NoResetPin,
 >;
 
-pub struct PicoExplorer {
+pub struct PicoExplorer<'a> {
     pub a: Pin<Gpio12, FunctionSioInput, PullUp>,
     pub b: Pin<Gpio13, FunctionSioInput, PullUp>,
     pub x: Pin<Gpio14, FunctionSioInput, PullUp>,
     pub y: Pin<Gpio15, FunctionSioInput, PullUp>,
     adc: Adc,
-    pub screen: Screen,
+    pub screen: Screen<'a>,
 }
 
-pub struct DummyPin;
+static SPI_BUFFER: StaticCell<[u8; 1024]> = StaticCell::new();
 
-impl OutputPin for DummyPin {
-    type Error = ();
-    fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+// Newtype wrapper implementing the delay trait from EH 1.0.
+struct Hal10Delay<'a>(&'a mut Delay);
+
+// This block is copied from (the currently unreleased) commit 5573370 of the cortex-m crate.
+impl<'a> DelayNs for Hal10Delay<'a> {
+    #[inline]
+    fn delay_ns(&mut self, ns: u32) {
+        // from the rp2040-hal:
+        let us = ns / 1000 + if ns % 1000 == 0 { 0 } else { 1 };
+        // With rustc 1.73, this can be replaced by:
+        // let us = ns.div_ceil(1000);
+        Delay::delay_us(self.0, us)
     }
-    fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+
+    #[inline]
+    fn delay_us(&mut self, us: u32) {
+        Delay::delay_us(self.0, us)
+    }
+
+    #[inline]
+    fn delay_ms(&mut self, ms: u32) {
+        Delay::delay_ms(self.0, ms)
     }
 }
 
-impl PicoExplorer {
+impl<'a> PicoExplorer<'a> {
     pub fn new(
         io: pac::IO_BANK0,
         pads: pac::PADS_BANK0,
@@ -193,7 +217,7 @@ impl PicoExplorer {
         spi0: SPI0,
         adc: Adc,
         resets: &mut RESETS,
-        delay: &mut impl DelayUs<u32>,
+        delay: &mut Delay,
     ) -> (Self, Pins) {
         let internal_pins = all_pins::Pins::new(io, pads, sio, resets);
 
@@ -212,16 +236,14 @@ impl PicoExplorer {
         let spi_sclk = internal_pins.spi_sclk.reconfigure();
         let spi_mosi = internal_pins.spi_mosi.reconfigure();
 
-        let spi_screen =
+        let spi_bus =
             Spi::new(spi0, (spi_mosi, spi_sclk)).init(resets, 125u32.MHz(), 16u32.MHz(), MODE_0);
-
-        let spii_screen = SPIInterface::new(spi_screen, dc, cs);
-
-        let mut screen = ST7789::new(spii_screen, DummyPin, 240, 240);
-
-        screen.init(delay).unwrap();
-        screen
-            .set_orientation(st7789::Orientation::Portrait)
+        let spi_device = ExclusiveDevice::new_no_delay(spi_bus, cs).unwrap();
+        let spi_buffer = SPI_BUFFER.init([0; _]);
+        let di = SpiInterface::new(spi_device, dc, spi_buffer);
+        let mut screen = Builder::new(ST7789, di)
+            .display_size(240, 240)
+            .init(&mut Hal10Delay(delay))
             .unwrap();
         screen.clear(Rgb565::BLACK).unwrap();
 


### PR DESCRIPTION
The _pimoroni-pico-explorer_ currently uses the _ST7789_ driver which is [deprecated](https://github.com/almindor/st7789?tab=readme-ov-file#deprecation-warning). Moreover the driver implements a 3.5 years old version of _embedded-graphics_, which is quickly becoming unusable.

This PR switches to the recommended [mipidsi driver](https://github.com/almindor/mipidsi). I have successfully tested the example on my own Pico Explorer board.